### PR TITLE
Added missing batch/agg functions

### DIFF
--- a/batch/aggregator.go
+++ b/batch/aggregator.go
@@ -11,9 +11,6 @@ import (
 type AggFunc func(in []schema.Point) float64
 
 func Avg(in []schema.Point) float64 {
-	if len(in) == 0 {
-		panic("avg() called in aggregator with 0 terms")
-	}
 	valid := float64(0)
 	sum := float64(0)
 	for _, term := range in {
@@ -42,9 +39,6 @@ func Cnt(in []schema.Point) float64 {
 }
 
 func Lst(in []schema.Point) float64 {
-	if len(in) == 0 {
-		panic("last() called in aggregator with 0 terms")
-	}
 	lst := math.NaN()
 	for _, v := range in {
 		if !math.IsNaN(v.Val) {
@@ -55,9 +49,6 @@ func Lst(in []schema.Point) float64 {
 }
 
 func Min(in []schema.Point) float64 {
-	if len(in) == 0 {
-		panic("min() called in aggregator with 0 terms")
-	}
 	valid := false
 	min := math.Inf(1)
 	for _, v := range in {
@@ -75,9 +66,6 @@ func Min(in []schema.Point) float64 {
 }
 
 func Max(in []schema.Point) float64 {
-	if len(in) == 0 {
-		panic("max() called in aggregator with 0 terms")
-	}
 	valid := false
 	max := math.Inf(-1)
 	for _, v := range in {

--- a/batch/aggregator.go
+++ b/batch/aggregator.go
@@ -6,6 +6,7 @@ package batch
 import (
 	"gopkg.in/raintank/schema.v1"
 	"math"
+	"sort"
 )
 
 type AggFunc func(in []schema.Point) float64
@@ -80,6 +81,87 @@ func Max(in []schema.Point) float64 {
 		max = math.NaN()
 	}
 	return max
+}
+
+func Mult(in []schema.Point) float64 {
+	valid := false
+	mult := float64(1)
+	for _, term := range in {
+		if math.IsNaN(term.Val) {
+			// NaN * anything equals NaN()
+			mult = math.NaN()
+			break
+		}
+		valid = true
+		mult *= term.Val
+	}
+	if !valid {
+		mult = math.NaN()
+	}
+	return mult
+}
+
+func Med(in []schema.Point) float64 {
+	med := float64(0)
+	vals := make([]float64, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		p := in[i].Val
+		if !math.IsNaN(p) {
+			vals = append(vals, p)
+		}
+	}
+	if len(vals) == 0 {
+		med = math.NaN()
+	} else {
+		sort.Float64s(vals)
+		mid := len(vals) / 2
+		if len(vals)%2 == 0 {
+			med = (vals[mid-1] + vals[mid]) / 2
+		} else {
+			med = vals[mid]
+		}
+	}
+	return med
+}
+
+func Diff(in []schema.Point) float64 {
+	diff := math.NaN()
+	for i := 0; i < len(in); i++ {
+		p := in[i].Val
+		if !math.IsNaN(p) {
+			if math.IsNaN(diff) {
+				diff = p
+			} else {
+				diff -= p
+			}
+		}
+	}
+	return diff
+}
+
+func StdDev(in []schema.Point) float64 {
+	avg := Avg(in)
+	if !math.IsNaN(avg) {
+		num := float64(0)
+		totalDeviationSquared := float64(0)
+		for i := 0; i < len(in); i++ {
+			p := in[i].Val
+			if !math.IsNaN(p) {
+				num++
+				deviation := p - avg
+				totalDeviationSquared += deviation * deviation
+			}
+		}
+		std := math.Sqrt(totalDeviationSquared / num)
+		return std
+	}
+	return math.NaN()
+}
+
+func Range(in []schema.Point) float64 {
+	min := Min(in)
+	max := Max(in)
+	return max - min
 }
 
 func Sum(in []schema.Point) float64 {


### PR DESCRIPTION
Basically ported over https://github.com/grafana/metrictank/blob/master/expr/seriesaggregators.go

Also removed panics since they all return math.NaN
```
median
def safeMedian(values):
  safeValues = [v for v in values if v is not None]
  if safeValues:
    sortedVals = sorted(safeValues)
    mid = len(sortedVals) // 2
    if len(sortedVals) % 2 == 0:
      return float(sortedVals[mid-1] + sortedVals[mid]) / 2
    else:
      return sortedVals[mid]

diff
def safeDiff(values):
  safeValues = [v for v in values if v is not None]
  if safeValues:
    values = list(map(lambda x: x*-1, safeValues[1:]))
    values.insert(0, safeValues[0])
    return sum(values)

stddev
def safeStdDev(a):
  sm = safeSum(a)
  ln = safeLen(a)
  avg = safeDiv(sm,ln)
  if avg is None: return None
  sum = 0
  safeValues = [v for v in a if v is not None]
  for val in safeValues:
     sum = sum + (val - avg) * (val - avg)
  return math.sqrt(sum/ln)

range
  'range': lambda row: safeSubtract(safeMax(row), safeMin(row)),

multiply
  'multiply': lambda row: safeMul(*row),
def safeMul(*factors):
  if None in factors:
    return None

  factors = [float(x) for x in factors]
  product = reduce(lambda x,y: x*y, factors)
  return product
```