### PR TITLE
Use strings as keys until both non-string ids are used everywhere

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -62,7 +62,7 @@ type Tree struct {
 	Items map[string]*Node // key is the full path of the node.
 }
 
-type IdSet map[idx.MetricID]struct{} // set of ids
+type IdSet map[string]struct{} // set of ids
 
 func (ids IdSet) String() string {
 	var res string
@@ -70,7 +70,7 @@ func (ids IdSet) String() string {
 		if len(res) > 0 {
 			res += " "
 		}
-		res += id.String()
+		res += id
 	}
 	return res
 
@@ -79,7 +79,7 @@ func (ids IdSet) String() string {
 type TagValue map[string]IdSet    // value -> set of ids
 type TagIndex map[string]TagValue // key -> list of values
 
-func (t *TagIndex) addTagId(name, value string, id idx.MetricID) {
+func (t *TagIndex) addTagId(name, value string, id string) {
 	ti := *t
 	if _, ok := ti[name]; !ok {
 		ti[name] = make(TagValue)
@@ -90,7 +90,7 @@ func (t *TagIndex) addTagId(name, value string, id idx.MetricID) {
 	ti[name][value][id] = struct{}{}
 }
 
-func (t *TagIndex) delTagId(name, value string, id idx.MetricID) {
+func (t *TagIndex) delTagId(name, value string, id string) {
 	ti := *t
 
 	delete(ti[name][value], id)
@@ -251,15 +251,6 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 		m.tags[def.OrgId] = tags
 	}
 
-	id, err := idx.NewMetricIDFromString(def.Id)
-	if err != nil {
-		// should never happen because all IDs in the index must have
-		// a valid format
-		invalidId.Inc()
-		log.Error(3, "memory-idx: ID %q has invalid format", def.Id)
-		return
-	}
-
 	for _, tag := range def.Tags {
 		tagSplits := strings.SplitN(tag, "=", 2)
 		if len(tagSplits) < 2 {
@@ -272,9 +263,9 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 
 		tagName := tagSplits[0]
 		tagValue := tagSplits[1]
-		tags.addTagId(tagName, tagValue, id)
+		tags.addTagId(tagName, tagValue, def.Id)
 	}
-	tags.addTagId("name", def.Name, id)
+	tags.addTagId("name", def.Name, def.Id)
 
 	m.defByTagSet.add(def)
 }
@@ -285,15 +276,6 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 // unsuccessful, "true" means the indexing was at least partially or completely
 // successful
 func (m *MemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDefinition) bool {
-	id, err := idx.NewMetricIDFromString(def.Id)
-	if err != nil {
-		// should never happen because all IDs in the index must have
-		// a valid format
-		invalidId.Inc()
-		log.Error(3, "memory-idx: ID %q has invalid format", def.Id)
-		return false
-	}
-
 	for _, tag := range def.Tags {
 		tagSplits := strings.SplitN(tag, "=", 2)
 		if len(tagSplits) < 2 {
@@ -306,10 +288,10 @@ func (m *MemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDefinition) boo
 
 		tagName := tagSplits[0]
 		tagValue := tagSplits[1]
-		tags.delTagId(tagName, tagValue, id)
+		tags.delTagId(tagName, tagValue, def.Id)
 	}
 
-	tags.delTagId("name", def.Name, id)
+	tags.delTagId("name", def.Name, def.Id)
 
 	m.defByTagSet.del(def)
 
@@ -514,7 +496,7 @@ func (m *MemoryIdx) TagDetails(orgId int, key, filter string, from int64) (map[s
 		count := uint64(0)
 		if from > 0 {
 			for id := range ids {
-				def, ok := m.defById[id.String()]
+				def, ok := m.defById[id]
 				if !ok {
 					corruptIndex.Inc()
 					log.Error(3, "memory-idx: corrupt. ID %q is in tag index but not in the byId lookup table", id)
@@ -669,7 +651,7 @@ func (m *MemoryIdx) FindTagValues(orgId int, tag, prefix string, expressions []s
 		for id := range ids {
 			var ok bool
 			var def *idx.Archive
-			if def, ok = m.defById[id.String()]; !ok {
+			if def, ok = m.defById[id]; !ok {
 				// should never happen because every ID in the tag index
 				// must be present in the byId lookup table
 				corruptIndex.Inc()
@@ -785,7 +767,7 @@ func (m *MemoryIdx) Tags(orgId int, filter string, from int64) ([]string, error)
 func (m *MemoryIdx) hasOneMetricFrom(tags TagIndex, tag string, from int64) bool {
 	for _, ids := range tags[tag] {
 		for id := range ids {
-			def, ok := m.defById[id.String()]
+			def, ok := m.defById[id]
 			if !ok {
 				corruptIndex.Inc()
 				log.Error(3, "memory-idx: corrupt. ID %q is in tag index but not in the byId lookup table", id)
@@ -819,7 +801,7 @@ func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) ([]id
 	ids := m.idsByTagQuery(orgId, query)
 	res := make([]idx.Node, 0, len(ids))
 	for id := range ids {
-		def, ok := m.defById[id.String()]
+		def, ok := m.defById[id]
 		if !ok {
 			corruptIndex.Inc()
 			log.Error(3, "memory-idx: corrupt. ID %q has been given, but it is not in the byId lookup table", id)
@@ -1065,7 +1047,7 @@ func (m *MemoryIdx) deleteTaggedByIdSet(orgId int, ids IdSet) []idx.Archive {
 
 	deletedDefs := make([]idx.Archive, 0, len(ids))
 	for id := range ids {
-		idStr := id.String()
+		idStr := id
 		def, ok := m.defById[idStr]
 		if !ok {
 			// not necessarily a corruption, the id could have been deleted
@@ -1267,13 +1249,7 @@ DEFS:
 			}
 
 			for def := range defs {
-				id, err := idx.NewMetricIDFromString(def.Id)
-				if err != nil {
-					log.Error(3, "memory-idx: corrupt index. ID format %s seems to be invalid", def.Id)
-					continue
-				}
-
-				toPruneTagged[def.OrgId][id] = struct{}{}
+				toPruneTagged[def.OrgId][def.Id] = struct{}{}
 			}
 		}
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
-var ids []idx.MetricID
+var ids []string
 
-func getTestIDs(t *testing.T) []idx.MetricID {
+func getTestIDs(t *testing.T) []string {
 	if len(ids) > 0 {
 		return ids
 	}
@@ -29,11 +29,7 @@ func getTestIDs(t *testing.T) []idx.MetricID {
 		"1.72345678901234567890123456789012",
 	}
 	for _, idStr := range idStrings {
-		id, err := idx.NewMetricIDFromString(idStr)
-		if err != nil {
-			t.Fatalf("Did not expect an error when converting id string to object: %s", idStr)
-		}
-		ids = append(ids, id)
+		ids = append(ids, idStr)
 	}
 
 	return ids
@@ -41,7 +37,7 @@ func getTestIDs(t *testing.T) []idx.MetricID {
 
 func getTestIndex(t *testing.T) (TagIndex, map[string]*idx.Archive) {
 	type testCase struct {
-		id         idx.MetricID
+		id         string
 		lastUpdate int64
 		tags       []string
 	}
@@ -63,7 +59,7 @@ func getTestIndex(t *testing.T) (TagIndex, map[string]*idx.Archive) {
 	byId := make(map[string]*idx.Archive)
 
 	for i, d := range data {
-		idStr := d.id.String()
+		idStr := d.id
 		byId[idStr] = &idx.Archive{}
 		byId[idStr].Name = fmt.Sprintf("metric%d", i)
 		byId[idStr].Tags = d.tags
@@ -393,12 +389,12 @@ func TestGetByTag(t *testing.T) {
 
 	idString := "1.000000000000000000000000000000%02x"
 	mds := make([]schema.MetricData, 20)
-	ids := make([]idx.MetricID, 20)
+	ids := make([]string, 20)
 	for i := range mds {
-		ids[i], _ = idx.NewMetricIDFromString(fmt.Sprintf(idString, i))
+		ids[i] = fmt.Sprintf(idString, i)
 		mds[i].Metric = fmt.Sprintf("metric.%d", i)
 		mds[i].Name = mds[i].Metric
-		mds[i].Id = ids[i].String()
+		mds[i].Id = ids[i]
 		mds[i].OrgId = 1
 		mds[i].Interval = 1
 		mds[i].Time = 12345
@@ -473,9 +469,9 @@ func TestGetByTag(t *testing.T) {
 
 		resPaths := make([]string, 0, len(res))
 		for id := range res {
-			def, ok := ix.defById[id.String()]
+			def, ok := ix.defById[id]
 			if !ok {
-				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id.String())
+				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id)
 			}
 			resPaths = append(resPaths, def.NameWithTags())
 		}


### PR DESCRIPTION
The basic idea here is that the string representation of an id is already in use by the defById map. During the course of indexing and querying, we are repeatedly doing fmt calls to translate between the two types. I think the original motivation behind using `Id` over string was [to reduce pointer usage for the GC](https://github.com/grafana/metrictank/pull/729#issuecomment-333380116) but this results in many allocations during a tag query. Here is my comparison with the existing benchmark (`1m` benchtime):

Improvements across the board (especially in allocations) except for indexing, which is pretty close.
```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkTagQueryFilterAndIntersect-8              74609352      55922356      -25.05%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     146186085     117200507     -19.83%
BenchmarkTagQueryKeysByPrefixSimple-8              3825          3298          -13.78%
BenchmarkTagQueryKeysByPrefixExpressions-8         1082002       793130        -26.70%
BenchmarkIndexing-8                                11962         12970         +8.43%

benchmark                                          old allocs     new allocs     delta
BenchmarkTagQueryFilterAndIntersect-8              403615         3256           -99.19%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     1005682        205082         -79.61%
BenchmarkTagQueryKeysByPrefixSimple-8              14             6              -57.14%
BenchmarkTagQueryKeysByPrefixExpressions-8         5389           1065           -80.24%
BenchmarkIndexing-8                                27             26             -3.70%

benchmark                                          old bytes     new bytes     delta
BenchmarkTagQueryFilterAndIntersect-8              9180205       383341        -95.82%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     31116455      13526309      -56.53%
BenchmarkTagQueryKeysByPrefixSimple-8              528           352           -33.33%
BenchmarkTagQueryKeysByPrefixExpressions-8         332176        253633        -23.64%
BenchmarkIndexing-8                                2007          1911          -4.78%
```