### PR TITLE
Limit series

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -320,13 +320,8 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 		result[resp.peer.GetName()] = resp
 	}
 
-	select {
-	case err := <-errorChan:
-		return nil, err
-	default: // no error
-	}
-
-	return result, nil
+	err := <-errorChan
+	return result, err
 }
 
 // peerQuerySpeculativeChan takes a request and the path to request it on, then fans it out

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -337,10 +337,10 @@ func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Trac
 	resultChan := make(chan PeerResponse)
 	errorChan := make(chan error, 1)
 
-	defer close(errorChan)
-	defer close(resultChan)
-
 	go func() {
+		defer close(errorChan)
+		defer close(resultChan)
+
 		peerGroups, err := cluster.MembersForSpeculativeQuery()
 		if err != nil {
 			log.Error(3, "HTTP peerQuery unable to get peers, %s", err)

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -313,22 +313,20 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 // path:         path to request on
 func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceable, name, path string) (map[string]PeerResponse, error) {
 	result := make(map[string]PeerResponse)
-	responseChan := make(chan PeerResponse)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var err error
-	go func() {
-		err = s.peerQuerySpeculativeChan(ctx, data, name, path, responseChan)
-		wg.Done()
-	}()
+	responseChan, errorChan := s.peerQuerySpeculativeChan(ctx, data, name, path)
 
 	for resp := range responseChan {
 		result[resp.peer.GetName()] = resp
 	}
 
-	wg.Wait()
-	return result, err
+	select {
+	case err := <-errorChan:
+		return nil, err
+	default: // no error
+	}
+
+	return result, nil
 }
 
 // peerQuerySpeculativeChan takes a request and the path to request it on, then fans it out
@@ -340,104 +338,115 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 // name:         name to be used in logging & tracing
 // path:         path to request on
 // resultChan:   channel to put responses on as they come in
-func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Traceable, name, path string, resultChan chan PeerResponse) error {
+func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Traceable, name, path string) (<-chan PeerResponse, <-chan error) {
+	resultChan := make(chan PeerResponse)
+	errorChan := make(chan error, 1)
+
+	defer close(errorChan)
 	defer close(resultChan)
 
-	peerGroups, err := cluster.MembersForSpeculativeQuery()
-	if err != nil {
-		log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
-		return err
-	}
-	log.Debug("HTTP %s across %d instances", name, len(peerGroups)-1)
-
-	reqCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	originalPeers := make(map[string]struct{}, len(peerGroups))
-	receivedResponses := make(map[int32]struct{}, len(peerGroups))
-
-	responses := make(chan struct {
-		shardGroup int32
-		data       PeerResponse
-		err        error
-	}, 1)
-
-	askPeer := func(shardGroup int32, peer cluster.Node) {
-		log.Debug("HTTP Render querying %s%s", peer.GetName(), path)
-		buf, err := peer.Post(reqCtx, name, path, data)
-
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			// Not canceled, continue
-		}
-
+	go func() {
+		peerGroups, err := cluster.MembersForSpeculativeQuery()
 		if err != nil {
-			cancel()
-			log.Error(4, "HTTP Render error querying %s%s: %q", peer.GetName(), path, err)
+			log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
+			errorChan <- err
+			return
 		}
-		responses <- struct {
+		log.Debug("HTTP %s across %d instances", name, len(peerGroups)-1)
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		originalPeers := make(map[string]struct{}, len(peerGroups))
+		receivedResponses := make(map[int32]struct{}, len(peerGroups))
+
+		responses := make(chan struct {
 			shardGroup int32
 			data       PeerResponse
 			err        error
-		}{shardGroup, PeerResponse{peer, buf}, err}
-	}
+		}, 1)
 
-	for group, peers := range peerGroups {
-		peer := peers[0]
-		originalPeers[peer.GetName()] = struct{}{}
-		go askPeer(group, peer)
-	}
+		askPeer := func(shardGroup int32, peer cluster.Node) {
+			log.Debug("HTTP Render querying %s%s", peer.GetName(), path)
+			buf, err := peer.Post(reqCtx, name, path, data)
 
-	var ticker *time.Ticker
-	var tickChan <-chan time.Time
-	if speculationThreshold != 1 {
-		ticker = time.NewTicker(5 * time.Millisecond)
-		tickChan = ticker.C
-		defer ticker.Stop()
-	}
-
-	for len(receivedResponses) < len(peerGroups) {
-		select {
-		case resp := <-responses:
-			if _, ok := receivedResponses[resp.shardGroup]; ok {
-				// already received this response (possibly speculatively)
-				continue
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// Not canceled, continue
 			}
 
-			if resp.err != nil {
-				return resp.err
+			if err != nil {
+				cancel()
+				log.Error(4, "HTTP Render error querying %s%s: %q", peer.GetName(), path, err)
 			}
+			responses <- struct {
+				shardGroup int32
+				data       PeerResponse
+				err        error
+			}{shardGroup, PeerResponse{peer, buf}, err}
+		}
 
-			resultChan <- resp.data
-			receivedResponses[resp.shardGroup] = struct{}{}
-			delete(originalPeers, resp.data.peer.GetName())
+		for group, peers := range peerGroups {
+			peer := peers[0]
+			originalPeers[peer.GetName()] = struct{}{}
+			go askPeer(group, peer)
+		}
 
-		case <-tickChan:
-			// Check if it's time to speculate!
-			percentReceived := float64(len(receivedResponses)) / float64(len(peerGroups))
-			if percentReceived >= speculationThreshold {
-				// kick off speculative queries to other members now
-				ticker.Stop()
-				speculativeAttempts.Inc()
-				for shardGroup, peers := range peerGroups {
-					if _, ok := receivedResponses[shardGroup]; ok {
-						continue
-					}
-					eligiblePeers := peers[1:]
-					for _, peer := range eligiblePeers {
-						speculativeRequests.Inc()
-						go askPeer(shardGroup, peer)
+		var ticker *time.Ticker
+		var tickChan <-chan time.Time
+		if speculationThreshold != 1 {
+			ticker = time.NewTicker(5 * time.Millisecond)
+			tickChan = ticker.C
+			defer ticker.Stop()
+		}
+
+		for len(receivedResponses) < len(peerGroups) {
+			select {
+			case <-ctx.Done():
+				//request canceled
+				return
+			case resp := <-responses:
+				if _, ok := receivedResponses[resp.shardGroup]; ok {
+					// already received this response (possibly speculatively)
+					continue
+				}
+
+				if resp.err != nil {
+					errorChan <- resp.err
+					return
+				}
+
+				resultChan <- resp.data
+				receivedResponses[resp.shardGroup] = struct{}{}
+				delete(originalPeers, resp.data.peer.GetName())
+
+			case <-tickChan:
+				// Check if it's time to speculate!
+				percentReceived := float64(len(receivedResponses)) / float64(len(peerGroups))
+				if percentReceived >= speculationThreshold {
+					// kick off speculative queries to other members now
+					ticker.Stop()
+					speculativeAttempts.Inc()
+					for shardGroup, peers := range peerGroups {
+						if _, ok := receivedResponses[shardGroup]; ok {
+							continue
+						}
+						eligiblePeers := peers[1:]
+						for _, peer := range eligiblePeers {
+							speculativeRequests.Inc()
+							go askPeer(shardGroup, peer)
+						}
 					}
 				}
 			}
 		}
-	}
 
-	if len(originalPeers) > 0 {
-		speculativeWins.Inc()
-	}
+		if len(originalPeers) > 0 {
+			speculativeWins.Inc()
+		}
+	}()
 
-	return nil
+	return resultChan, errorChan
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -294,7 +294,7 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 	result := make(map[string]PeerResponse)
 	for resp := range responses {
 		if resp.err != nil {
-			return nil, err
+			return nil, resp.err
 		}
 		result[resp.data.peer.GetName()] = resp.data
 	}
@@ -312,10 +312,41 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 // name:         name to be used in logging & tracing
 // path:         path to request on
 func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceable, name, path string) (map[string]PeerResponse, error) {
+	result := make(map[string]PeerResponse)
+	responseChan := make(chan PeerResponse)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var err error
+	go func() {
+		err = s.peerQuerySpeculativeChan(ctx, data, name, path, responseChan)
+		wg.Done()
+	}()
+
+	for resp := range responseChan {
+		result[resp.peer.GetName()] = resp
+	}
+
+	wg.Wait()
+	return result, err
+}
+
+// peerQuerySpeculativeChan takes a request and the path to request it on, then fans it out
+// across the cluster. If any peer fails requests to other peers are aborted. If enough
+// peers have been heard from (based on speculation-threshold configuration), and we
+// are missing the others, try to speculatively query other members of the shard group.
+// ctx:          request context
+// data:         request to be submitted
+// name:         name to be used in logging & tracing
+// path:         path to request on
+// resultChan:   channel to put responses on as they come in
+func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Traceable, name, path string, resultChan chan PeerResponse) error {
+	defer close(resultChan)
+
 	peerGroups, err := cluster.MembersForSpeculativeQuery()
 	if err != nil {
 		log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
-		return nil, err
+		return err
 	}
 	log.Debug("HTTP %s across %d instances", name, len(peerGroups)-1)
 
@@ -359,8 +390,6 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 		go askPeer(group, peer)
 	}
 
-	result := make(map[string]PeerResponse)
-
 	var ticker *time.Ticker
 	var tickChan <-chan time.Time
 	if speculationThreshold != 1 {
@@ -378,10 +407,10 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 			}
 
 			if resp.err != nil {
-				return nil, err
+				return resp.err
 			}
 
-			result[resp.data.peer.GetName()] = resp.data
+			resultChan <- resp.data
 			receivedResponses[resp.shardGroup] = struct{}{}
 			delete(originalPeers, resp.data.peer.GetName())
 
@@ -410,5 +439,5 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 		speculativeWins.Inc()
 	}
 
-	return result, nil
+	return nil
 }

--- a/api/config.go
+++ b/api/config.go
@@ -40,7 +40,7 @@ func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
 	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
 	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
-	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 200000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
+	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 250000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")

--- a/api/config.go
+++ b/api/config.go
@@ -15,6 +15,7 @@ import (
 var (
 	maxPointsPerReqSoft int
 	maxPointsPerReqHard int
+	maxSeriesPerReq     int
 	logMinDurStr        string
 	logMinDur           uint32
 
@@ -39,6 +40,7 @@ func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
 	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
 	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
+	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 200000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -675,7 +676,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 			for i, e := range exprs {
 				exprs[i] = strings.Trim(e, " '\"")
 			}
-			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From))
+			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From), maxSeriesPerReq-len(reqs))
 		} else {
 			series, err = s.findSeries(ctx, orgId, []string{r.Query}, int64(r.From))
 		}
@@ -868,7 +869,7 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId uint32, tag, filte
 
 func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.GraphiteTagFindSeries) {
 	reqCtx := ctx.Req.Context()
-	series, err := s.clusterFindByTag(reqCtx, ctx.OrgId, request.Expr, request.From)
+	series, err := s.clusterFindByTag(reqCtx, ctx.OrgId, request.Expr, request.From, maxSeriesPerReq)
 	if err != nil {
 		response.Write(ctx, response.WrapError(err))
 		return
@@ -888,28 +889,40 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 	response.Write(ctx, response.NewJson(200, seriesNames, ""))
 }
 
-func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64) ([]Series, error) {
+func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64, maxSeries int) ([]Series, error) {
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
-	resps, err := s.peerQuerySpeculative(ctx, data, "clusterFindByTag", "/index/find_by_tag")
-	if err != nil {
-		return nil, err
-	}
+	responseChan := make(chan PeerResponse)
 
-	select {
-	case <-ctx.Done():
-		//request canceled
-		return nil, nil
-	default:
-	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var queryErr, err error
+	go func() {
+		queryErr = s.peerQuerySpeculativeChan(ctx, data, "clusterFindByTag", "/index/find_by_tag", responseChan)
+		wg.Done()
+	}()
 
 	var allSeries []Series
 
-	for _, r := range resps {
+	for r := range responseChan {
+		select {
+		case <-ctx.Done():
+			//request canceled
+			return nil, nil
+		default:
+		}
+
 		resp := models.IndexFindByTagResp{}
 		_, err = resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}
+
+		// 0 disables the check, so only check if maxSeriesPerReq > 0
+		if maxSeriesPerReq > 0 && len(resp.Metrics)+len(allSeries) > maxSeries {
+			return nil,
+				response.NewError(413, fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
+		}
+
 		for _, series := range resp.Metrics {
 			allSeries = append(allSeries, Series{
 				Pattern: series.Path,
@@ -919,7 +932,8 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		}
 	}
 
-	return allSeries, nil
+	wg.Wait()
+	return allSeries, queryErr
 }
 
 func (s *Server) graphiteTags(ctx *middleware.Context, request models.GraphiteTags) {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -917,13 +917,8 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		}
 	}
 
-	select {
-	case err := <-errorChan:
-		return nil, err
-	default: // no error
-	}
-
-	return allSeries, nil
+	err := <-errorChan
+	return allSeries, err
 }
 
 func (s *Server) graphiteTags(ctx *middleware.Context, request models.GraphiteTags) {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -891,28 +891,13 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 
 func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64, maxSeries int) ([]Series, error) {
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
-	responseChan := make(chan PeerResponse)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var queryErr, err error
-	go func() {
-		queryErr = s.peerQuerySpeculativeChan(ctx, data, "clusterFindByTag", "/index/find_by_tag", responseChan)
-		wg.Done()
-	}()
+	responseChan, errorChan := s.peerQuerySpeculativeChan(ctx, data, "clusterFindByTag", "/index/find_by_tag")
 
 	var allSeries []Series
 
 	for r := range responseChan {
-		select {
-		case <-ctx.Done():
-			//request canceled
-			return nil, nil
-		default:
-		}
-
 		resp := models.IndexFindByTagResp{}
-		_, err = resp.UnmarshalMsg(r.buf)
+		_, err := resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}
@@ -932,8 +917,13 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		}
 	}
 
-	wg.Wait()
-	return allSeries, queryErr
+	select {
+	case err := <-errorChan:
+		return nil, err
+	default: // no error
+	}
+
+	return allSeries, nil
 }
 
 func (s *Server) graphiteTags(ctx *middleware.Context, request models.GraphiteTags) {

--- a/api/prometheus_querier.go
+++ b/api/prometheus_querier.go
@@ -64,7 +64,7 @@ func (q *querier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error)
 		}
 	}
 
-	series, err := q.clusterFindByTag(q.ctx, q.OrgID, expressions, 0)
+	series, err := q.clusterFindByTag(q.ctx, q.OrgID, expressions, 0, maxSeriesPerReq)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -201,7 +202,8 @@ func (n HTTPNode) GetName() string {
 func handleResp(rsp *http.Response) ([]byte, error) {
 	defer rsp.Body.Close()
 	if rsp.StatusCode != 200 {
-		ioutil.ReadAll(rsp.Body)
+		// Read in body so that the connection can be reused
+		io.Copy(ioutil.Discard, rsp.Body)
 		return nil, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
 	}
 	return ioutil.ReadAll(rsp.Body)

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -156,6 +156,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite


### PR DESCRIPTION
This is to prevent OOM issues when users (purposefully or accidentally) ask for too many time-series. From some tests on our side, the size of a time-series response is about 450 bytes * number of series, so accounting for all 250k (the default) would be about 112MB of just raw response buffer, plus the decoded size, plus the capacity overhead (since the responses buffers aren't precisely size) is probably about 250MB (1kB per series). At that point, we just give up. 

The next step is more efficiently decode the peer responses in a streaming manner directly into the in-memory struct (msgp supports it, but we have to worry about the body being closed so I haven't found a clean way yet). At any rate, that would likely be a larger change, so I went with just limiting it first, and making it better second.