### PR TITLE
fix one more corruption case

### DIFF
--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -185,6 +185,8 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 		})
 		mc.chunks[ts] = &chunks[len(chunks)-1]
 		mc.keys = append(mc.keys, ts)
+	} else {
+		mc.chunks[ts].Prev = prev
 	}
 
 	if sortKeys {


### PR DESCRIPTION
This is based on your working branch, so I create a PR to that. It fixes one additional possible corruption case.

Cases such as this one are probably rare, but cannot be ruled out because between searching the cache and adding to the cache the locks are released:
```
		ccm.AddRange(0, chunks[3:6])
		ccm.AddRange(0, chunks[0:4])
```
I think the `verifyCcm()` function might also be useful in finding more cases that can create corruptions.