### PR TITLE
Feature instrument render

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -580,7 +580,7 @@ func (s *Server) metricsDeleteRemote(ctx context.Context, orgId uint32, query st
 
 // executePlan looks up the needed data, retrieves it, and then invokes the processing
 // note if you do something like sum(foo.*) and all of those metrics happen to be on another node,
-// we will collect all the indidividual series from the peer, and then sum here. that could be optimized
+// we will collect all the individual series from the peer, and then sum here. that could be optimized
 func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) ([]models.Series, error) {
 
 	preExecutePlan := time.Now()

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -583,6 +583,7 @@ func (s *Server) metricsDeleteRemote(ctx context.Context, orgId uint32, query st
 // we will collect all the indidividual series from the peer, and then sum here. that could be optimized
 func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) ([]models.Series, error) {
 
+	preExecutePlan := time.Now()
 	minFrom := uint32(math.MaxUint32)
 	var maxTo uint32
 	var reqs []models.Req
@@ -706,6 +707,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 	out, err = plan.Run(data)
 	planRunDuration.Value(time.Since(preRun))
 	stats["planRunTime"] = util.MsSince(preRun)
+	stats["executePlanTime"] = util.MsSince(preExecutePlan)
 	for i,_ := range out {
 		out[i].Stats = stats
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -377,7 +377,6 @@ func (s *Server) metricsIndex(ctx *middleware.Context) {
 		return
 	default:
 	}
-
 	response.Write(ctx, response.NewFastJson(200, models.MetricNames(series)))
 }
 
@@ -587,7 +586,9 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 	minFrom := uint32(math.MaxUint32)
 	var maxTo uint32
 	var reqs []models.Req
+	stats := make(map[string]float64)
 
+	preGetSeries := time.Now()
 	// note that different patterns to query can have different from / to, so they require different index lookups
 	// e.g. target=movingAvg(foo.*, "1h")&target=foo.*
 	// note that in this case we fetch foo.* twice. can be optimized later
@@ -642,15 +643,17 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 			}
 		}
 	}
-
+	stats["getSeriesTime"] = util.MsSince(preGetSeries)
 	select {
 	case <-ctx.Done():
 		//request canceled
 		return nil, nil
 	default:
 	}
+	num_series_req := len(reqs)
+	reqRenderSeriesCount.Value(num_series_req)
+	stats["seriesFetched"] = float64(num_series_req)
 
-	reqRenderSeriesCount.Value(len(reqs))
 	if len(reqs) == 0 {
 		return nil, nil
 	}
@@ -661,6 +664,8 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 		log.Errorf("HTTP Render alignReq error: %s", err.Error())
 		return nil, err
 	}
+	stats["pointsFetched"] = float64(pointsFetch)
+	stats["pointsReturned"] = float64(pointsReturn)
 	span := opentracing.SpanFromContext(ctx)
 	span.SetTag("num_reqs", len(reqs))
 	span.SetTag("points_fetch", pointsFetch)
@@ -670,11 +675,15 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 		log.Debugf("HTTP Render %s - arch:%d archI:%d outI:%d aggN: %d from %s", req, req.Archive, req.ArchInterval, req.OutInterval, req.AggNum, req.Node.GetName())
 	}
 
+	preGetTargets := time.Now()
 	out, err := s.getTargets(ctx, reqs)
+	stats["getTargetsTime"] = util.MsSince(preGetTargets)
 	if err != nil {
 		log.Errorf("HTTP Render %s", err.Error())
 		return nil, err
 	}
+
+	preRunLogic := time.Now()
 
 	out = mergeSeries(out)
 
@@ -691,10 +700,16 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 	for k := range data {
 		sort.Sort(models.SeriesByTarget(data[k]))
 	}
+	stats["preRunLogicTime"] = util.MsSince(preRunLogic)
 
 	preRun := time.Now()
 	out, err = plan.Run(data)
 	planRunDuration.Value(time.Since(preRun))
+	stats["planRunTime"] = util.MsSince(preRun)
+	for i,_ := range out {
+		out[i].Stats = stats
+	}
+
 	return out, err
 }
 

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -114,6 +114,7 @@ func (series SeriesByTarget) MarshalJSONFast(b []byte) ([]byte, error) {
 			// Replace trailing comma with a closing bracket
 			b[len(b)-1] = '}'
 		}
+		// 'stats' will not be included if request was proxied to graphite
 		b = append(b, `,"stats":{`...)
 		for stat, value := range s.Stats {
 			b = strconv.AppendQuoteToASCII(b, stat)

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -15,6 +15,7 @@ import (
 
 type Series struct {
 	Target       string // for fetched data, set from models.Req.Target, i.e. the metric graphite key. for function output, whatever should be shown as target string (legend)
+	Stats 		 map[string]float64 // stats
 	Datapoints   []schema.Point
 	Tags         map[string]string // Must be set initially via call to `SetTags()`
 	Interval     uint32
@@ -113,6 +114,15 @@ func (series SeriesByTarget) MarshalJSONFast(b []byte) ([]byte, error) {
 			// Replace trailing comma with a closing bracket
 			b[len(b)-1] = '}'
 		}
+		b = append(b, `,"stats":{`...)
+		for stat, value := range s.Stats {
+			b = strconv.AppendQuoteToASCII(b, stat)
+			b = append(b, ':')
+			b = strconv.AppendFloat(b, value, 'f', -1, 64)
+			b = append(b, ',')
+		}
+		// Replace trailing comma with a closing bracket
+		b[len(b)-1] = '}'
 		b = append(b, `,"datapoints":[`...)
 		for _, p := range s.Datapoints {
 			b = append(b, '[')

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,7 @@
 package util
 
+import "time"
+
 func Min(a, b uint32) uint32 {
 	if a < b {
 		return a
@@ -44,4 +46,8 @@ func Lcm(vals []uint32) uint32 {
 
 func IsDigit(r byte) bool {
 	return '0' <= r && r <= '9'
+}
+
+func MsSince(prev time.Time) float64 {
+	return float64(time.Since(prev)) / float64(time.Millisecond)
 }


### PR DESCRIPTION
For https://github.com/grafana/metrictank/issues/1130

New Stat Names (all times in ms - will rename to include `Ms` if advised): 

* Time spent resolving the targets into a concrete list of series: `getSeriesTime`
* Time spent fetching the data: `getTargetsTime`
* Time spent executing pre-run logic: `preRunLogicTime`
* Time spent on `Plan.Run`: `preRunTime`
* Time spent on `executePlan`: `executePlanTime`

Names of following based on https://github.com/grafana/metrictank/blob/master/api/query_engine.go#L18-L21
* Number of points pulled in: `pointsFetched`
* Number of points returned: `pointsReturned`
* Number of series pulled in: `seriesFetched`