### PR TITLE
backfill tool

### DIFF
--- a/cmd/mt-backfill/main.go
+++ b/cmd/mt-backfill/main.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	l "log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/grafana/globalconf"
+	"github.com/grafana/metrictank/api"
+	"github.com/grafana/metrictank/cluster"
+	"github.com/grafana/metrictank/idx"
+	"github.com/grafana/metrictank/idx/memory"
+	"github.com/grafana/metrictank/input"
+	inKafka "github.com/grafana/metrictank/input/kafkamdm"
+	"github.com/grafana/metrictank/logger"
+	"github.com/grafana/metrictank/mdata"
+	"github.com/grafana/metrictank/mdata/cache"
+	cassandraStore "github.com/grafana/metrictank/store/cassandra"
+	"github.com/raintank/dur"
+	"github.com/raintank/schema"
+	"github.com/raintank/schema/msg"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// metrictank
+	aggMetrics  *mdata.AggMetrics
+	metricIndex idx.MetricIndex
+	apiServer   *api.Server
+	inputKafka  input.Plugin
+	store       mdata.Store
+
+	// config file
+	confFile = flag.String("config", "/etc/metrictank/metrictank.ini", "config file path")
+
+	// Data: the following configs are the same with the normal metrictank configs:
+	chunkMaxStaleStr  = flag.String("chunk-max-stale", "1m", "chunk max stale age.")
+	metricMaxStaleStr = flag.String("metric-max-stale", "5m", "metric max stale age.")
+	gcIntervalStr     = flag.String("gc-interval", "2m", "gc interval.")
+	publicOrg         = flag.Int("public-org", 0, "org Id")
+
+	// backfilling
+	backfillEnd = "backfillEnd" // message used by input stream to indicate the end of backfilling
+	lastRcvTime int64           // epoch time when the previous kafka message was received
+	mux         sync.Mutex      // mutex to protect lastRcvTime
+	handler     inputHandler    // input message handler to track the last kafka receive event and handles kafka messages
+)
+
+// a kafka mesage handler that implements the input.Handler interface
+type inputHandler struct {
+	dHandler input.DefaultHandler // default handler that processes metric metadata and points
+	finished chan bool            // this will be set if a message contains backfillEnd
+}
+
+func newInputHandler(metrics mdata.Metrics, metricIndex idx.MetricIndex, pluginName string) inputHandler {
+	dh := input.NewDefaultHandler(metrics, metricIndex, pluginName)
+	return inputHandler{
+		dHandler: dh,
+		finished: make(chan bool),
+	}
+}
+
+// input.Handler interface
+func (ih inputHandler) ProcessMetricData(metric *schema.MetricData, partition int32) {
+	if strings.Contains(metric.Name, backfillEnd) {
+		ih.finished <- true
+		return
+	}
+	ih.dHandler.ProcessMetricData(metric, partition)
+	mux.Lock()
+	defer mux.Unlock()
+	lastRcvTime = int64(time.Now().Unix())
+}
+
+// input.Handler interface
+func (ih inputHandler) ProcessMetricPoint(point schema.MetricPoint, format msg.Format, partition int32) {
+	ih.dHandler.ProcessMetricPoint(point, format, partition)
+	mux.Lock()
+	defer mux.Unlock()
+	lastRcvTime = int64(time.Now().Unix())
+}
+
+func main() {
+	log.Infof("metrictank backfilling")
+
+	flag.Parse()
+
+	// logger
+	formatter := &logger.TextFormatter{}
+	formatter.TimestampFormat = "2019-03-21 10:00:00.000"
+	log.SetFormatter(formatter)
+	log.SetLevel(log.InfoLevel)
+
+	// Only try and parse the conf file if it exists
+	path := ""
+	if _, err := os.Stat(*confFile); err == nil {
+		path = *confFile
+	}
+	config, err := globalconf.NewWithOptions(&globalconf.Options{
+		Filename:  path,
+		EnvPrefix: "MT_",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configuration file error: %s", err)
+		os.Exit(1)
+	}
+
+	// load configs
+	inKafka.ConfigSetup()
+	memory.ConfigSetup()
+	api.ConfigSetup()
+	cluster.ConfigSetup()
+	mdata.ConfigSetup()
+	cassandraStore.ConfigSetup()
+	config.ParseAll()
+
+	// cluster is required because of aggMetric.add()
+	// this should be configured as single mode
+	api.ConfigProcess()
+	cluster.ConfigProcess()
+	addrParts := strings.Split(api.Addr, ":")
+	port, err := strconv.ParseInt(addrParts[len(addrParts)-1], 10, 64)
+	if err != nil {
+		log.Fatalf("Could not parse port from listenAddr. %s", api.Addr)
+	}
+	cluster.Init("backfill", "none", time.Now(), "http", int(port))
+
+	// other settings
+	inKafka.ConfigProcess("backfill")
+	mdata.ConfigProcess()
+	memory.ConfigProcess()
+
+	// interrupt signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// backend store
+	cassandraStore.CliConfig.Enabled = true
+	store, err = cassandraStore.NewCassandraStore(cassandraStore.CliConfig, mdata.TTLs())
+	if err != nil {
+		log.Fatalf("failed to initialize cassandra store. %s", err)
+	}
+
+	// chunk cache
+	ccache := cache.NewCCache()
+
+	// memory store
+	chunkMaxStale := dur.MustParseNDuration("chunk-max-stale", *chunkMaxStaleStr)
+	metricMaxStale := dur.MustParseNDuration("metric-max-stale", *metricMaxStaleStr)
+	gcInterval := time.Duration(dur.MustParseNDuration("gc-interval", *gcIntervalStr)) * time.Second
+	aggMetrics = mdata.NewAggMetrics(store, nil, false, chunkMaxStale, metricMaxStale, gcInterval)
+
+	// input
+	// we use kafkamdm as input
+	inKafka.Enabled = true
+	sarama.Logger = l.New(os.Stdout, "[Sarama] ", l.LstdFlags)
+	inputKafka = inKafka.New()
+
+	// cluster manager
+	cluster.Start()
+
+	if *publicOrg < 0 {
+		log.Fatal("public-org cannot be <0")
+	}
+	idx.OrgIdPublic = uint32(*publicOrg)
+
+	memory.Enabled = true
+	metricIndex = memory.New()
+
+	// api server
+	apiServer, err = api.NewServer()
+	if err != nil {
+		log.Fatalf("Failed to start api server. %s", err.Error())
+	}
+	apiServer.BindMetricIndex(metricIndex)
+	apiServer.BindMemoryStore(aggMetrics)
+	apiServer.BindBackendStore(store)
+	apiServer.BindCache(ccache) // chunk cache should be disabled
+	apiServer.BindPromQueryEngine()
+
+	go apiServer.Run()
+
+	// load index entries
+	err = metricIndex.Init()
+	if err != nil {
+		log.Fatalf("Failed to initialize metricIndex: %s", err.Error())
+	}
+
+	// start input
+	ctx, cancel := context.WithCancel(context.Background())
+	handler = newInputHandler(aggMetrics, metricIndex, "kafkamdm")
+	err = inputKafka.Start(handler, cancel)
+	if err != nil {
+		shutdown()
+		log.Warn("Cannot start input.")
+		return
+	}
+	inputKafka.MaintainPriority()
+	apiServer.BindPrioritySetter(inputKafka)
+	lastRcvTime = int64(time.Now().Unix())
+	go handlerTimeout()
+
+	cluster.Manager.SetReady()
+
+	// wait for shutdown
+	select {
+	case sig := <-sigChan:
+		log.Infof("Received signal %q. Shutting down", sig)
+	case <-ctx.Done():
+		log.Info("The input plugin signalled a fatal error. Shutting down")
+	case <-handler.finished:
+		log.Infof("Received finished signal from input handler. Shutting down")
+	}
+	shutdown()
+
+	defer cancel()
+}
+
+// if there is no update in 3 mins, shut down the tool
+func handlerTimeout() {
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case now := <-ticker.C:
+			mux.Lock()
+			prevRcv := lastRcvTime
+			mux.Unlock()
+			// wait for 3 minutes, if there is no more input, shut down
+			if now.Unix()-prevRcv > 180 {
+				log.Infof("Handler timeout, shutting down")
+				handler.finished <- true
+				ticker.Stop()
+				return
+			}
+		}
+	}
+}
+
+// normal shutdown
+func shutdown() {
+	cluster.Stop()
+	apiServer.Stop()
+	timer := time.NewTimer(time.Second * 20)
+	kafkaStopped := make(chan bool)
+	go func() {
+		log.Infof("Shutting down kafka consumer")
+		inputKafka.Stop()
+		log.Infof("kafka consumer finished shutdown")
+		kafkaStopped <- true
+	}()
+
+	select {
+	case <-timer.C:
+		log.Warn("Plugin shutdown timeout.")
+	case <-kafkaStopped:
+		timer.Stop()
+	}
+	store.Stop()
+	log.Info("shutting down.")
+}

--- a/cmd/mt-backfill/main.go
+++ b/cmd/mt-backfill/main.go
@@ -45,7 +45,7 @@ var (
 	metricMaxStaleStr = flag.String("metric-max-stale", "5m", "metric max stale age.")
 	gcIntervalStr     = flag.String("gc-interval", "2m", "gc interval.")
 	publicOrg         = flag.Int("public-org", 0, "org Id")
-    timeout           = flag.Int("timeout", 10, "the tool will exit if no kafka message is received during this interval ")
+	timeout           = flag.Int("timeout", 10, "the tool will exit if no kafka message is received during this interval ")
 
 	// backfilling
 	lastRcvTime int64        // epoch time when the previous kafka message was received
@@ -243,4 +243,3 @@ func shutdown() {
 	store.Stop()
 	log.Info("shutting down.")
 }
-


### PR DESCRIPTION
This is a backfill tool used to fill in the historical data. Here we assume that the metric meta data has already been stored in Cassandra.

This tool will read data from a kafkamdm input plugin and store the data into Cassandra store.

The tool will exit if there is no new data in 3 minutes.