### PR TITLE
Add constantLine function

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -757,10 +757,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 	}
 
 	reqRenderSeriesCount.ValueUint32(reqs.cnt)
-	if reqs.cnt == 0 {
-		return nil, meta, nil
-	}
-
+	
 	meta.RenderStats.SeriesFetch = reqs.cnt
 
 	// note: if 1 series has a movingAvg that requires a long time range extension, it may push other reqs into another archive. can be optimized later

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -59,7 +59,7 @@ See also:
 | changed                                                        |              | No         |
 | color                                                          |              | No         |
 | consolidateBy(seriesList, func) seriesList                     |              | Stable     |
-| constantLine                                                   |              | No         |
+| constantLine                                                   |              | Stable     |
 | countSeries(seriesLists) series                                |              | Stable     |
 | cumulative                                                     |              | Stable     |
 | currentAbove                                                   |              | Stable     |

--- a/expr/func_constantline.go
+++ b/expr/func_constantline.go
@@ -1,7 +1,7 @@
 package expr
 
 import (
-	"strconv"
+	"fmt"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
@@ -26,8 +26,8 @@ func (s *FuncConstantLine) Signature() ([]Arg, []Arg) {
 }
 
 func (s *FuncConstantLine) Context(context Context) Context {
-	s.from = context.from
-	s.to = context.to
+	s.from = context.from - 1
+	s.to = context.to - 1
 	return context
 }
 
@@ -39,7 +39,7 @@ func (s *FuncConstantLine) Exec(dataMap DataMap) ([]models.Series, error) {
 			schema.Point{Val: s.value, Ts: s.to},
 		)
 
-	strValue := strconv.FormatFloat(s.value, 'f', -1, 64)
+	strValue := fmt.Sprintf("%g", s.value)
 
 	outputs := make([]models.Series, 1)
 	outputs[0] = models.Series{
@@ -47,6 +47,7 @@ func (s *FuncConstantLine) Exec(dataMap DataMap) ([]models.Series, error) {
 		QueryPatt: strValue,
 		Datapoints: out,
 	}
+	outputs[0].SetTags()
 
 	dataMap.Add(Req{}, outputs...)
 	return outputs, nil

--- a/expr/func_constantline.go
+++ b/expr/func_constantline.go
@@ -1,0 +1,53 @@
+package expr
+
+import (
+	"strconv"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+)
+
+type FuncConstantLine struct {
+	value float64
+	from  uint32
+	to    uint32
+}
+
+func NewConstantLine() GraphiteFunc {
+	return &FuncConstantLine{}
+}
+
+func (s *FuncConstantLine) Signature() ([]Arg, []Arg) {
+	return []Arg{
+			ArgFloat{key: "value", val: &s.value},
+		}, []Arg{
+			ArgSeriesList{},
+		}
+}
+
+func (s *FuncConstantLine) Context(context Context) Context {
+	s.from = context.from
+	s.to = context.to
+	return context
+}
+
+func (s *FuncConstantLine) Exec(dataMap DataMap) ([]models.Series, error) {
+	out := pointSlicePool.Get().([]schema.Point)
+	out = append(out,
+			schema.Point{Val: s.value, Ts: s.from},
+			schema.Point{Val: s.value, Ts: s.from + uint32((s.to-s.from)/2.0)},
+			schema.Point{Val: s.value, Ts: s.to},
+		)
+
+	strValue := strconv.FormatFloat(s.value, 'f', -1, 64)
+
+	outputs := make([]models.Series, 1)
+	outputs[0] = models.Series{
+		Target: strValue,
+		QueryPatt: strValue,
+		Datapoints: out,
+	}
+
+	dataMap.Add(Req{}, outputs...)
+	return outputs, nil
+}

--- a/expr/func_constantline.go
+++ b/expr/func_constantline.go
@@ -34,17 +34,17 @@ func (s *FuncConstantLine) Context(context Context) Context {
 func (s *FuncConstantLine) Exec(dataMap DataMap) ([]models.Series, error) {
 	out := pointSlicePool.Get().([]schema.Point)
 	out = append(out,
-			schema.Point{Val: s.value, Ts: s.from},
-			schema.Point{Val: s.value, Ts: s.from + uint32((s.to-s.from)/2.0)},
-			schema.Point{Val: s.value, Ts: s.to},
-		)
+		schema.Point{Val: s.value, Ts: s.from},
+		schema.Point{Val: s.value, Ts: s.from + uint32((s.to-s.from)/2.0)},
+		schema.Point{Val: s.value, Ts: s.to},
+	)
 
 	strValue := fmt.Sprintf("%g", s.value)
 
 	outputs := make([]models.Series, 1)
 	outputs[0] = models.Series{
-		Target: strValue,
-		QueryPatt: strValue,
+		Target:     strValue,
+		QueryPatt:  strValue,
 		Datapoints: out,
 	}
 	outputs[0].SetTags()

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -106,7 +106,7 @@ func TestConstantLineLargeInt(t *testing.T) {
 	}
 }
 
-func TestConstantLineSmallFloatLowPrec(t *testing.T) {
+func TestConstantLineLargeFloatLowPrec(t *testing.T) {
 	cases := []ConstantLineTestCase {
 		{
 			name: "constantLine(1000000000.234)",
@@ -123,7 +123,7 @@ func TestConstantLineSmallFloatLowPrec(t *testing.T) {
 	}
 }
 
-func TestConstantLineSmallFloatHighPrec(t *testing.T) {
+func TestConstantLineLargeFloatHighPrec(t *testing.T) {
 	cases := []ConstantLineTestCase {
 		{
 			name: "constantLine(1000000000.2345678912345)",

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -12,22 +12,22 @@ import (
 )
 
 type ConstantLineTestCase struct {
-	name 	string
-	value 	float64
+	name  string
+	value float64
 }
 
 func TestConstantLineSmallInt(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1)",
+			name:  "constantLine(1)",
 			value: 1,
 		},
 		{
-			name: "constantLine(100)",
+			name:  "constantLine(100)",
 			value: 100,
 		},
 		{
-			name: "constantLine(10000)",
+			name:  "constantLine(10000)",
 			value: 10000,
 		},
 	}
@@ -36,17 +36,17 @@ func TestConstantLineSmallInt(t *testing.T) {
 }
 
 func TestConstantLineSmallFloatLowPrec(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1.234)",
+			name:  "constantLine(1.234)",
 			value: 1.234,
 		},
 		{
-			name: "constantLine(100.234)",
+			name:  "constantLine(100.234)",
 			value: 100.234,
 		},
 		{
-			name: "constantLine(10000.234)",
+			name:  "constantLine(10000.234)",
 			value: 10000.234,
 		},
 	}
@@ -55,17 +55,17 @@ func TestConstantLineSmallFloatLowPrec(t *testing.T) {
 }
 
 func TestConstantLineSmallFloatHighPrec(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1.2345678912345)",
+			name:  "constantLine(1.2345678912345)",
 			value: 1.2345678912345,
 		},
 		{
-			name: "constantLine(100.2345678912345)",
+			name:  "constantLine(100.2345678912345)",
 			value: 100.2345678912345,
 		},
 		{
-			name: "constantLine(10000.2345678912345)",
+			name:  "constantLine(10000.2345678912345)",
 			value: 10000.2345678912345,
 		},
 	}
@@ -73,15 +73,14 @@ func TestConstantLineSmallFloatHighPrec(t *testing.T) {
 	testConstantLineWrapper(cases, t)
 }
 
-
 func TestConstantLineLargeInt(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1000000000)",
+			name:  "constantLine(1000000000)",
 			value: 1000000000,
 		},
 		{
-			name: "constantLine(1000000000000)",
+			name:  "constantLine(1000000000000)",
 			value: 1000000000000,
 		},
 	}
@@ -90,13 +89,13 @@ func TestConstantLineLargeInt(t *testing.T) {
 }
 
 func TestConstantLineLargeFloatLowPrec(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1000000000.234)",
+			name:  "constantLine(1000000000.234)",
 			value: 1000000000.234,
 		},
 		{
-			name: "constantLine(1000000000000.234)",
+			name:  "constantLine(1000000000000.234)",
 			value: 1000000000000.234,
 		},
 	}
@@ -105,13 +104,13 @@ func TestConstantLineLargeFloatLowPrec(t *testing.T) {
 }
 
 func TestConstantLineLargeFloatHighPrec(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1000000000.2345678912345)",
+			name:  "constantLine(1000000000.2345678912345)",
 			value: 1000000000.2345678912345,
 		},
 		{
-			name: "constantLine(1000000000000.2345678912345)",
+			name:  "constantLine(1000000000000.2345678912345)",
 			value: 1000000000000.2345678912345,
 		},
 	}
@@ -120,9 +119,9 @@ func TestConstantLineLargeFloatHighPrec(t *testing.T) {
 }
 
 func TestConstantLineFloatTooManyDecimals(t *testing.T) {
-	cases := []ConstantLineTestCase {
+	cases := []ConstantLineTestCase{
 		{
-			name: "constantLine(1.23456789123456789123456789)",
+			name:  "constantLine(1.23456789123456789123456789)",
 			value: 1.23456789123456789123456789,
 		},
 	}
@@ -151,11 +150,11 @@ func testConstantLineWrapper(cases []ConstantLineTestCase, t *testing.T) {
 	}
 }
 
-func makeConstantLineSeries(value float64, from uint32, to uint32) ([]models.Series) {
+func makeConstantLineSeries(value float64, from uint32, to uint32) []models.Series {
 	series := []models.Series{
 		{
-			Target:		 fmt.Sprintf("%g", value),
-			QueryPatt:   fmt.Sprintf("%g", value),
+			Target:    fmt.Sprintf("%g", value),
+			QueryPatt: fmt.Sprintf("%g", value),
 			Datapoints: []schema.Point{
 				{Val: value, Ts: from},
 				{Val: value, Ts: from + uint32((to-from)/2.0)},
@@ -169,7 +168,7 @@ func makeConstantLineSeries(value float64, from uint32, to uint32) ([]models.Ser
 
 func testConstantLine(name string, value float64, from uint32, to uint32, out []models.Series, t *testing.T) {
 	f := NewConstantLine()
-	f.(*FuncConstantLine).value  = value
+	f.(*FuncConstantLine).value = value
 	f.(*FuncConstantLine).from = from
 	f.(*FuncConstantLine).to = to
 	got, err := f.Exec(make(map[Req][]models.Series))

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -1,7 +1,7 @@
 package expr
 
 import (
-	"math"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -16,20 +16,25 @@ func TestConstantLineSimple(t *testing.T) {
 		1,
 		0,
 		100,
-		makeConstantLineSeries(1, 0, 100)
+		makeConstantLineSeries(1, 0, 100),
+		t,
 	)
 }
 
 func makeConstantLineSeries(value float64, from uint32, to uint32) ([]models.Series) {
-	return []models.Series{
-		Target:		 fmt.Sprintf("%g", value),
-		QueryPatt:   fmt.Sprintf("%g", value),
-		Datapoints: []schema.Point{
-			{Val: value, Ts: from},
-			{Val: value, Ts: from + uint32((to-from)/2.0)},
-			{Val: value, Ts: to},
+	series := []models.Series{
+		{
+			Target:		 fmt.Sprintf("%g", value),
+			QueryPatt:   fmt.Sprintf("%g", value),
+			Datapoints: []schema.Point{
+				{Val: value, Ts: from},
+				{Val: value, Ts: from + uint32((to-from)/2.0)},
+				{Val: value, Ts: to},
+			},
 		},
 	}
+
+	return series
 }
 
 func testConstantLine(name string, value float64, from uint32, to uint32, out []models.Series, t *testing.T) {
@@ -37,7 +42,7 @@ func testConstantLine(name string, value float64, from uint32, to uint32, out []
 	f.(*FuncConstantLine).value  = value
 	f.(*FuncConstantLine).from = from
 	f.(*FuncConstantLine).to = to
-	gots, err = f.Exec(make(map[Req][]models.Series))
+	gots, err := f.Exec(make(map[Req][]models.Series))
 
 	if err != nil {
 		t.Fatalf("case %q: err should be nil. got %q", name, err)
@@ -117,8 +122,8 @@ func benchmarkConstantLine(b *testing.B, numSeries int, fn0, fn1 func() []schema
 	for i := 0; i < b.N; i++ {
 		f := NewConstantLine()
 		f.(*FuncConstantLine).value = 1.0
-		f.(*FuncConstantLine).from = 1584849600000
-		f.(*FuncConstantLine).to = 1584849660000
+		f.(*FuncConstantLine).from = 1584849600
+		f.(*FuncConstantLine).to = 1584849660
 		got, err := f.Exec(make(map[Req][]models.Series))
 		if err != nil {
 			b.Fatalf("%s", err)

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
@@ -15,16 +16,6 @@ type ConstantLineTestCase struct {
 	value 	float64
 }
 
-// array of time ranges
-// 1s, 1m, 1hr, 1day, 30days, 400days
-var timeRanges = []uint32{
-	1,
-	60,
-	3600,
-	86400,
-	2592000,
-	34560000,
-}
 func TestConstantLineSmallInt(t *testing.T) {
 	cases := []ConstantLineTestCase {
 		{
@@ -41,9 +32,7 @@ func TestConstantLineSmallInt(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 func TestConstantLineSmallFloatLowPrec(t *testing.T) {
@@ -62,9 +51,7 @@ func TestConstantLineSmallFloatLowPrec(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 func TestConstantLineSmallFloatHighPrec(t *testing.T) {
@@ -83,9 +70,7 @@ func TestConstantLineSmallFloatHighPrec(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 
@@ -101,9 +86,7 @@ func TestConstantLineLargeInt(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 func TestConstantLineLargeFloatLowPrec(t *testing.T) {
@@ -118,9 +101,7 @@ func TestConstantLineLargeFloatLowPrec(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 func TestConstantLineLargeFloatHighPrec(t *testing.T) {
@@ -135,9 +116,7 @@ func TestConstantLineLargeFloatHighPrec(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
 func TestConstantLineFloatTooManyDecimals(t *testing.T) {
@@ -148,14 +127,27 @@ func TestConstantLineFloatTooManyDecimals(t *testing.T) {
 		},
 	}
 
-	for _, to := range timeRanges {
-		testConstantLineWrapper(cases, 0, to, t)
-	}
+	testConstantLineWrapper(cases, t)
 }
 
-func testConstantLineWrapper(cases []ConstantLineTestCase, from uint32, to uint32, t *testing.T) {
+func testConstantLineWrapper(cases []ConstantLineTestCase, t *testing.T) {
+	// array of time ranges
+	// 1s, 1m, 1hr, 1day, 30days, 400days
+	day := time.Hour * 24
+	timeRanges := []time.Duration{
+		time.Second,
+		time.Minute,
+		time.Hour,
+		day,
+		day * 30,
+		day * 400,
+	}
+
 	for _, c := range cases {
-		testConstantLine(c.name, c.value, from, to, makeConstantLineSeries(c.value, from, to), t)
+		for _, to := range timeRanges {
+			toInt := uint32(to)
+			testConstantLine(c.name, c.value, 0, toInt, makeConstantLineSeries(c.value, 0, toInt), t)
+		}
 	}
 }
 

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -1,0 +1,128 @@
+package expr
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/test"
+)
+
+func TestConstantLineSimple(t *testing.T) {
+	testConstantLine(
+		"simple",
+		1,
+		0,
+		100,
+		makeConstantLineSeries(1, 0, 100)
+	)
+}
+
+func makeConstantLineSeries(value float64, from uint32, to uint32) ([]models.Series) {
+	return []models.Series{
+		Target:		 fmt.Sprintf("%g", value),
+		QueryPatt:   fmt.Sprintf("%g", value),
+		Datapoints: []schema.Point{
+			{Val: value, Ts: from},
+			{Val: value, Ts: from + uint32((to-from)/2.0)},
+			{Val: value, Ts: to},
+		},
+	}
+}
+
+func testConstantLine(name string, value float64, from uint32, to uint32, out []models.Series, t *testing.T) {
+	f := NewConstantLine()
+	f.(*FuncConstantLine).value  = value
+	f.(*FuncConstantLine).from = from
+	f.(*FuncConstantLine).to = to
+	gots, err = f.Exec(make(map[Req][]models.Series))
+
+	if err != nil {
+		t.Fatalf("case %q: err should be nil. got %q", name, err)
+	}
+	if len(gots) != len(out) {
+		t.Fatalf("case %q: isNonNull len output expected %d, got %d", name, len(out), len(gots))
+	}
+
+	for i, g := range gots {
+		exp := out[i]
+		if g.QueryPatt != exp.QueryPatt {
+			t.Fatalf("case %q: expected target %q, got %q", name, exp.QueryPatt, g.QueryPatt)
+		}
+		if len(g.Datapoints) != len(exp.Datapoints) {
+			t.Fatalf("case %q: len output expected %d, got %d", name, len(exp.Datapoints), len(g.Datapoints))
+		}
+		for j, p := range g.Datapoints {
+			if (p.Val == exp.Datapoints[j].Val) && p.Ts == exp.Datapoints[j].Ts {
+				continue
+			}
+			t.Fatalf("case %q: output point %d - expected %v got %v", name, j, exp.Datapoints[j], p)
+		}
+	}
+}
+
+func BenchmarkConstantLine10k_1NoNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkConstantLine10k_10NoNulls(b *testing.B) {
+	benchmarkConstantLine(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkConstantLine10k_100NoNulls(b *testing.B) {
+	benchmarkConstantLine(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkConstantLine10k_1000NoNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkConstantLine10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkConstantLine10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkConstantLine(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+
+func benchmarkConstantLine(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewConstantLine()
+		f.(*FuncConstantLine).value = 1.0
+		f.(*FuncConstantLine).from = 1584849600000
+		f.(*FuncConstantLine).to = 1584849660000
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
+}

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -11,14 +11,11 @@ import (
 )
 
 func TestConstantLineSimple(t *testing.T) {
-	testConstantLine(
-		"simple",
-		1,
-		0,
-		100,
-		makeConstantLineSeries(1, 0, 100),
-		t,
-	)
+	testConstantLineWrapper("simple", 1, 0, 100, t)
+}
+
+func testConstantLineWrapper(name string, value float64, from uint32, to uint32, t *testing.T) {
+	testConstantLine(name, value, from, to, makeConstantLineSeries(value, from, to), t)
 }
 
 func makeConstantLineSeries(value float64, from uint32, to uint32) ([]models.Series) {

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -63,6 +63,7 @@ func init() {
 		"averageBelow":          {NewFilterSeriesConstructor("average", "<="), true},
 		"averageSeries":         {NewAggregateConstructor("average", crossSeriesAvg), true},
 		"consolidateBy":         {NewConsolidateBy, true},
+		"constantLine":          {NewConstantLine, true},
 		"countSeries":           {NewCountSeries, true},
 		"cumulative":            {NewConsolidateByConstructor("sum"), true},
 		"currentAbove":          {NewFilterSeriesConstructor("last", ">"), true},


### PR DESCRIPTION
**Describe your changes**
Adds the `constantLine` function

**Testing performed**
Test files added, plus `mtcmptest` with
```json
{
    "constantLine(1)": "constantLine(1)",
    "constantLine(10)": "constantLine(10)",
    "constantLine(100)": "constantLine(100)",
    "constantLine(1000)": "constantLine(1000)",
    "constantLine(10000)": "constantLine(10000)",
    "constantLine(100000)": "constantLine(100000)",
    "constantLine(1000000)": "constantLine(1000000)",
    "constantLine(10000000)": "constantLine(10000000)",
    "constantLine(0.01)": "constantLine(0.01)",
    "constantLine(0.001)": "constantLine(0.001)",
    "constantLine(0.0001)": "constantLine(0.0001)",
    "constantLine(0.00001)": "constantLine(0.00001)",
    "constantLine(0.000000000001)": "constantLine(0.000000000001)",
    "constantLine(0.1234512345": "constantLine(0.1234512345)",
    "constantLine(0.0100000000000000000)": "constantLine(0.0100000000000000000)",
    "constantLine(0.1234512345123451234)": "constantLine(0.1234512345123451234)"
}
```