### PR TITLE
RDTITELINF-4852 - Add traceID and some additional log-based request tracing

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -831,6 +831,9 @@ type consolidatorTuple struct {
 // we will collect all the individual series from the peer, and then sum here. that could be optimized
 func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan) ([]models.Series, models.RenderMeta, error) {
 	var meta models.RenderMeta
+	traceID, _ := tracing.ExtractTraceID(ctx)
+
+	log.Infof("executePlan: Starting traceID=%s req %v", traceID, plan.Reqs)
 
 	reqs := NewReqMap()
 	metaTagEnrichmentData := make(map[string]tagquery.Tags)
@@ -845,6 +848,11 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 			To:    r.To,
 		}
 		resolveSeriesRequests[strippedreq] = append(resolveSeriesRequests[strippedreq], plan.Reqs[i])
+	}
+
+	// Output to see how useful this optimization might be
+	if len(resolveSeriesRequests) != len(plan.Reqs) {
+		log.Infof("executePlan: traceID=%s Making %d roundtrips to resolve %d reqs", traceID, len(resolveSeriesRequests), len(plan.Reqs))
 	}
 
 	// note that different patterns to query can have different from / to, so they require different index lookups
@@ -1040,6 +1048,12 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 	meta.RenderStats.PlanRunDuration = time.Since(preRun)
 	planRunDuration.Value(meta.RenderStats.PlanRunDuration)
 	span.LogFields(traceLog.Float64("PlanRunMillis", durToMillis(meta.RenderStats.PlanRunDuration)))
+
+	// Log finished stats
+	// TODO - reusable buffer
+	prettyMeta, _ := meta.MarshalJSONFast(nil)
+	log.Infof("executePlan: Completed traceID=%s meta=%s err=%v", traceID, string(prettyMeta), err)
+
 	return out, meta, err
 }
 

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -9,6 +9,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	tags "github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/uber/jaeger-client-go"
 )
 
 // NewSpan pulls the span out of the context, creates a new child span, and updates the context
@@ -35,4 +36,18 @@ func Errorf(span opentracing.Span, format string, a ...interface{}) {
 // Failure marks the current request as a failure
 func Failure(span opentracing.Span) {
 	tags.Error.Set(span, true)
+}
+
+// ExtractTraceID attempts to extract the traceID from a Context
+func ExtractTraceID(ctx context.Context) (string, bool) {
+	sp := opentracing.SpanFromContext(ctx)
+	if sp == nil {
+		return "", false
+	}
+	sctx, ok := sp.Context().(jaeger.SpanContext)
+	if !ok {
+		return "", false
+	}
+
+	return sctx.TraceID().String(), sctx.IsSampled()
 }


### PR DESCRIPTION
**Describe your changes**

Add additional logging of request progress with `traceID`. Include:

1. `plan.Reqs` at the start of the query (so if the query node crashes, we know which in-flight requests were being processed).
1. meta stats at end of query time (These can be very useful stats to have in aggregate for debugging slow queries after the fact, in tandem with trace)

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
