### PR TITLE
Harden index load against failures on startup

### DIFF
--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -391,6 +391,12 @@ func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time
 			// (that's how Graphite works anyway)
 			LastUpdate: util.MinInt64(maxLastUpdate, lastupdate+updateInterval),
 		}
+
+		if err = mdef.Validate(); err != nil {
+			log.Errorf("Encountered invalid idx entry: def = %v, err = %v", mdef, err)
+			continue
+		}
+
 		nameWithTags := mdef.NameWithTags()
 		defsByNames[nameWithTags] = append(defsByNames[nameWithTags], mdef)
 	}

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -584,30 +584,40 @@ func TestPruneStaleOnLoad(t *testing.T) {
 	}
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(1).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "longtermrecentenough",
 		interval:   1,
 		lastUpdate: now.Add(-350 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(2).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "longtermtooold",
 		interval:   1,
 		lastUpdate: now.Add(-380 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(3).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "foobarrecentenough",
 		interval:   3,
 		lastUpdate: now.Add(-5 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(4).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "foobartooold",
 		interval:   3,
 		lastUpdate: now.Add(-9 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(5).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "default-super-old-but-never-pruned",
 		interval:   1,
 		lastUpdate: now.Add(-2 * 365 * 24 * time.Hour).Unix(),
@@ -661,6 +671,7 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(1).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   1,
@@ -671,6 +682,7 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(2).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   2,
@@ -681,20 +693,22 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(3).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   3,
 		lastUpdate: now.Add(-8 * 24 * time.Hour).Unix(), // this one will expire
-		tags:       []string{"tag1=val1;foo=bar"},
+		tags:       []string{"tag1=val1", "foo=bar"},
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(4).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   4,
 		lastUpdate: now.Add(-8 * 24 * time.Hour).Unix(), // this one won't because it doesn't match the tag
-		tags:       []string{"tag1=val1;foo=baz"},
+		tags:       []string{"tag1=val1", "foo=baz"},
 	})
 
 	idx := &CasIdx{}

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -614,7 +614,10 @@ func TestPruneStaleOnLoad(t *testing.T) {
 	})
 
 	idx := &CasIdx{}
-	defs := idx.load(nil, &iter, now)
+	defs, err := idx.load(nil, &iter, now)
+	if err != nil {
+		t.Fatalf("unexpected error when loading: %s", err)
+	}
 
 	exp := []schema.MKey{
 		test.GetMKey(1),
@@ -695,7 +698,11 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	})
 
 	idx := &CasIdx{}
-	defs := idx.load(nil, &iter, now)
+	defs, err := idx.load(nil, &iter, now)
+	if err != nil {
+		t.Fatalf("unexpected error when loading: %s", err)
+	}
+
 	exp := []schema.MKey{
 		test.GetMKey(1),
 		test.GetMKey(2),

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -44,6 +44,7 @@ type IdxConfig struct {
 	ProtoVer                 int
 	DisableInitialHostLookup bool
 	InitLoadConcurrency      int
+	InitLoadRetries          int
 }
 
 // NewIdxConfig returns IdxConfig with default values set.
@@ -74,6 +75,7 @@ func NewIdxConfig() *IdxConfig {
 		Username:                 "cassandra",
 		Password:                 "cassandra",
 		InitLoadConcurrency:      1,
+		InitLoadRetries:          3,
 	}
 }
 
@@ -107,6 +109,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.DurationVar(&CliConfig.updateInterval, "update-interval", CliConfig.updateInterval, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
 	casIdx.DurationVar(&CliConfig.pruneInterval, "prune-interval", CliConfig.pruneInterval, "Interval at which the index should be checked for stale series.")
 	casIdx.IntVar(&CliConfig.InitLoadConcurrency, "init-load-concurrency", CliConfig.InitLoadConcurrency, "Number of partitions to load concurrently on startup.")
+	casIdx.IntVar(&CliConfig.InitLoadRetries, "init-load-retries", CliConfig.InitLoadRetries, "Number of times to retry loading a partition on startup before failing.")
 	casIdx.IntVar(&CliConfig.ProtoVer, "protocol-version", CliConfig.ProtoVer, "cql protocol version to use")
 	casIdx.BoolVar(&CliConfig.CreateKeyspace, "create-keyspace", CliConfig.CreateKeyspace, "enable the creation of the index keyspace and tables, only one node needs this")
 	casIdx.StringVar(&CliConfig.SchemaFile, "schema-file", CliConfig.SchemaFile, "File containing the needed schemas in case database needs initializing")

--- a/test/key.go
+++ b/test/key.go
@@ -16,6 +16,7 @@ func GetAMKey(suffix int) schema.AMKey {
 func GetMKey(suffix int) schema.MKey {
 	s := uint32(suffix)
 	return schema.MKey{
+		Org: 1,
 		Key: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, byte(s >> 24), byte(s >> 16), byte(s >> 8), byte(s)},
 	}
 }


### PR DESCRIPTION
After a cassandra crash, invalid index entries caused MT to crash repeatedly. Additionally, there were spurious timeouts and metrictank cannot start if *any* partition failed to load. With even a low chance of partition failure (e.g. 10%) and 16 partitions to load, it's likely Metrictank will fail to start several times.  Add some retries so that it's much more likely all partitions succeed.