### PR TITLE
Archive by query

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1553,7 +1553,14 @@ func (s *Server) graphiteTagDelSeries(ctx *middleware.Context, request models.Gr
 func (s *Server) graphiteTagDelByQuery(ctx *middleware.Context, request models.GraphiteTagDelByQuery) {
 	res := models.GraphiteTagDelByQueryResp{}
 
-	data := models.IndexTagDelByQuery{OrgId: ctx.OrgId, Expr: request.Expr, OlderThan: request.OlderThan, Execute: request.Execute}
+	data := models.IndexTagDelByQuery{
+		OrgId:     ctx.OrgId,
+		Expr:      request.Expr,
+		OlderThan: request.OlderThan,
+		Execute:   request.Execute,
+		Method:    request.Method,
+	}
+	log.Infof("Sending request to peers: %v", data)
 	responses, errors := s.queryAllPeers(ctx.Req.Context(), data, "clusterTagDelByQuery,", "/index/tags/delByQuery")
 
 	// nothing to do locally on query nodes.

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -168,7 +168,8 @@ type GraphiteTagDelSeriesResp struct {
 type GraphiteTagDelByQuery struct {
 	Expr      []string `json:"expressions" binding:"Required"`
 	OlderThan int64    `json:"olderThan" form:"olderThan"`
-	Execute   bool     `json:execute binding:"Default(false)"`
+	Execute   bool     `json:"execute" binding:"Default(false)"`
+	Method    string   `json:"method" binding:"Default(delete);OmitEmpty;In(delete,archive)"`
 }
 
 func (g GraphiteTagDelByQuery) Trace(span opentracing.Span) {
@@ -176,6 +177,7 @@ func (g GraphiteTagDelByQuery) Trace(span opentracing.Span) {
 		traceLog.String("expressions", fmt.Sprintf("%q", g.Expr)),
 		traceLog.String("olderThan", fmt.Sprintf("%d", g.OlderThan)),
 		traceLog.String("execute", fmt.Sprintf("%t", g.Execute)),
+		traceLog.String("method", fmt.Sprintf("%s", g.Method)),
 	)
 }
 

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -162,7 +162,8 @@ type IndexTagDelByQuery struct {
 	OrgId     uint32   `json:"orgId" binding:"Required"`
 	Expr      []string `json:"expressions" binding:"Required"`
 	OlderThan int64    `json:"olderThan" form:"olderThan"`
-	Execute   bool     `json:execute binding:"Default(false)"`
+	Execute   bool     `json:"execute" binding:"Default(false)"`
+	Method    string   `json:"method" binding:"Default(delete);OmitEmpty;In(delete,archive)"`
 }
 
 func (t IndexTagDelByQuery) Trace(span opentracing.Span) {
@@ -170,6 +171,7 @@ func (t IndexTagDelByQuery) Trace(span opentracing.Span) {
 		traceLog.String("expressions", fmt.Sprintf("%q", t.Expr)),
 		traceLog.String("olderThan", fmt.Sprintf("%d", t.OlderThan)),
 		traceLog.String("execute", fmt.Sprintf("%t", t.Execute)),
+		traceLog.String("method", fmt.Sprintf("%s", t.Method)),
 	)
 }
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -617,6 +617,29 @@ func (c *CasIdx) DeleteTagged(orgId uint32, query tagquery.Query) ([]idx.Archive
 	return defs, err
 }
 
+func (c *CasIdx) ArchiveTagged(orgId uint32, query tagquery.Query) ([]idx.Archive, error) {
+
+	archives, err := c.MemoryIndex.DeleteTagged(orgId, query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Due to an unfortunate evolution, Archive and delete have 2 different
+	// interfaces (idx.Archive vs schema.MetricDefinition). So one more
+	// translation step to what ArchiveDefs needs.
+	defs := make([]schema.MetricDefinition, 0, len(archives))
+	for _, archive := range archives {
+		defs = append(defs, archive.MetricDefinition)
+	}
+
+	_, err = c.ArchiveDefs(defs)
+	if err != nil {
+		return nil, err
+	}
+
+	return archives, err
+}
+
 func (c *CasIdx) deleteDefs(defs []idx.Archive) error {
 	var err error
 


### PR DESCRIPTION
**Describe your changes**

See https://github.com/grafana/metrictank/issues/1977
Adds an option to `delByQuery` to archive data rather than delete it outright.

**Testing performed**

Basic testing of functionality:

- Default of `delete` works as existing
- `archive` works as expected
- `execute: false` works as existing

