### PR TITLE
Support batches of datapoints

### DIFF
--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -324,8 +324,7 @@ func (k *KafkaMdm) handleMsg(data []byte, partition int32) {
 		for iter.Next() {
 			k.Handler.ProcessMetricPoint(iter.Value(), iter.Format(), partition)
 		}
-		err := iter.Err()
-		if err != nil {
+		if err := iter.Err(); err != nil {
 			metricsDecodeErr.Inc()
 			log.Errorf("kafkamdm: decode metricpoint array error, skipping message. %s", err)
 		}

--- a/schema/msg/format.go
+++ b/schema/msg/format.go
@@ -11,4 +11,5 @@ const (
 	FormatMetricPoint
 	FormatMetricPointWithoutOrg
 	FormatIndexControlMessage
+	FormatMetricPointArray
 )

--- a/schema/msg/msg.go
+++ b/schema/msg/msg.go
@@ -112,6 +112,41 @@ func WritePointMsg(point schema.MetricPoint, buf []byte, version Format) (o []by
 	return nil, fmt.Errorf(errFmtUnsupportedFormat, version)
 }
 
+// WritePointMsgArray is like CreateMsg, except optimized for MetricPoint and buffer re-use.
+// caller must assure a cap-len diff of at least:
+// 2 + 32B * len(points) (for FormatMetricPoint)
+// 2 + 28B * len(points) (for FormatMetricPointWithoutOrg)
+// no other formats supported.
+func WritePointMsgArray(points []schema.MetricPoint, buf []byte, version Format) (o []byte, err error) {
+	if len(points) == 0 {
+		return buf, errTooSmall
+	}
+
+	b := buf[:2]
+	b[0] = byte(FormatMetricPointArray)
+	b[1] = byte(version)
+
+	var formatter func(m *schema.MetricPoint, b []byte) (o []byte, err error)
+
+	switch version {
+	case FormatMetricPoint:
+		formatter = (*schema.MetricPoint).Marshal32
+	case FormatMetricPointWithoutOrg:
+		formatter = (*schema.MetricPoint).MarshalWithoutOrg28
+	default:
+		return nil, fmt.Errorf(errFmtUnsupportedFormat, version)
+	}
+
+	for _, p := range points {
+		b, err = formatter(&p, b)
+		if err != nil {
+			return b, err
+		}
+	}
+
+	return b, nil
+}
+
 func IsPointMsg(data []byte) (Format, bool) {
 	l := len(data)
 	if l == 0 {
@@ -124,22 +159,90 @@ func IsPointMsg(data []byte) (Format, bool) {
 	if l == 33 && version == FormatMetricPoint {
 		return FormatMetricPoint, true
 	}
+	if l >= 30 && version == FormatMetricPointArray {
+		subversion := Format(data[1])
+		if subversion == FormatMetricPointWithoutOrg || subversion == FormatMetricPoint {
+			// TODO - check length multiple?
+			return FormatMetricPointArray, true
+		}
+	}
 	return 0, false
 }
 
 func ReadPointMsg(data []byte, defaultOrg uint32) ([]byte, schema.MetricPoint, error) {
-	var point schema.MetricPoint
 	version := Format(data[0])
-	if len(data) == 29 && version == FormatMetricPointWithoutOrg {
-		o, err := point.UnmarshalWithoutOrg(data[1:])
+	return ReadPointMsgFormat(data[1:], defaultOrg, version)
+}
+
+func ReadPointMsgFormat(data []byte, defaultOrg uint32, version Format) ([]byte, schema.MetricPoint, error) {
+	var point schema.MetricPoint
+	if len(data) >= 28 && version == FormatMetricPointWithoutOrg {
+		o, err := point.UnmarshalWithoutOrg(data)
 		point.MKey.Org = defaultOrg
 		return o, point, err
 	}
-	if len(data) == 33 && version == FormatMetricPoint {
-		o, err := point.Unmarshal(data[1:])
+	if len(data) >= 32 && version == FormatMetricPoint {
+		o, err := point.Unmarshal(data)
 		return o, point, err
 	}
 	return data, point, fmt.Errorf(errFmtUnsupportedFormat, version)
+}
+
+type MetricPointIter struct {
+	data       []byte
+	defaultOrg uint32
+	point      schema.MetricPoint
+	format     Format
+	err        error
+}
+
+func NewMetricPointIter(data []byte, defaultOrg uint32) MetricPointIter {
+	var result MetricPointIter
+	if len(data) < 30 {
+		result.err = errTooSmall
+		return result
+	}
+	version := Format(data[0])
+	if version != FormatMetricPointArray {
+		result.err = fmt.Errorf(errFmtUnsupportedFormat, version)
+		return result
+	}
+	subversion := Format(data[1])
+	if subversion != FormatMetricPointWithoutOrg && subversion != FormatMetricPoint {
+		result.err = fmt.Errorf(errFmtUnsupportedFormat, version)
+		return result
+	}
+
+	result.data = data[2:]
+	result.defaultOrg = defaultOrg
+	result.format = subversion
+
+	return result
+}
+
+func (m *MetricPointIter) Next() bool {
+	if len(m.data) == 0 {
+		// All done
+		return false
+	}
+	if len(m.data) < 28 {
+		m.err = errTooSmall
+		return false
+	}
+	m.data, m.point, m.err = ReadPointMsgFormat(m.data, m.defaultOrg, m.format)
+	return m.err == nil
+}
+
+func (m *MetricPointIter) Value() schema.MetricPoint {
+	return m.point
+}
+
+func (m *MetricPointIter) Format() Format {
+	return m.format
+}
+
+func (m *MetricPointIter) Err() error {
+	return m.err
 }
 
 func IsIndexControlMsg(data []byte) bool {

--- a/schema/msg/msg_test.go
+++ b/schema/msg/msg_test.go
@@ -74,6 +74,105 @@ func TestWriteReadPointMsgWithoutOrg(t *testing.T) {
 	}
 }
 
+func TestWriteReadPointMsgArray(t *testing.T) {
+	mp := []schema.MetricPoint{
+		{
+			MKey: schema.MKey{
+				Org: 123,
+			},
+			Time:  math.MaxUint32,
+			Value: 123.45,
+		},
+		{
+			MKey: schema.MKey{
+				Org: 1,
+			},
+			Time:  math.MaxUint32,
+			Value: 1,
+		},
+		{
+			MKey: schema.MKey{
+				Org: 2,
+			},
+			Time:  math.MaxUint32,
+			Value: 12,
+		},
+	}
+	buf := make([]byte, 0, 2+32*3)
+	out, err := WritePointMsgArray(mp, buf, FormatMetricPoint)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	_, ok := IsPointMsg(out)
+	if !ok {
+		t.Fatal("IsPointMsg: exp true, got false")
+	}
+
+	var outPoints []schema.MetricPoint
+	iter := NewMetricPointIter(out, 6)
+	for iter.Next() {
+		outPoints = append(outPoints, iter.Value())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("%s", iter.Err().Error())
+	}
+
+	if !reflect.DeepEqual(mp, outPoints) {
+		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	}
+}
+
+func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
+	mp := []schema.MetricPoint{
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 123.45,
+		},
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 1,
+		},
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 12,
+		},
+	}
+	buf := make([]byte, 0, 2+28*3)
+	out, err := WritePointMsgArray(mp, buf, FormatMetricPointWithoutOrg)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	_, ok := IsPointMsg(out)
+	if !ok {
+		t.Fatal("IsPointMsg: exp true, got false")
+	}
+
+	// iter will have to set the default org and we want to check it
+	for i := range mp {
+		mp[i].MKey.Org = 6
+	}
+
+	var outPoints []schema.MetricPoint
+	iter := NewMetricPointIter(out, 6)
+	for iter.Next() {
+		outPoints = append(outPoints, iter.Value())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("%s", iter.Err().Error())
+	}
+
+	if !reflect.DeepEqual(mp, outPoints) {
+		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	}
+}
+
 func TestWriteReadIndexControlMsg(t *testing.T) {
 	mp := schema.ControlMsg{
 		Op:   schema.OpArchive,

--- a/schema/msg/msg_test.go
+++ b/schema/msg/msg_test.go
@@ -98,7 +98,7 @@ func TestWriteReadPointMsgArray(t *testing.T) {
 			Value: 12,
 		},
 	}
-	buf := make([]byte, 0, 2+32*3)
+	buf := make([]byte, 0, 2+32*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPoint)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
@@ -142,7 +142,7 @@ func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
 			Value: 12,
 		},
 	}
-	buf := make([]byte, 0, 2+28*3)
+	buf := make([]byte, 0, 2+28*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPointWithoutOrg)
 	if err != nil {
 		t.Fatalf("%s", err.Error())


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

See issue https://github.com/grafana/metrictank/issues/1002. Will submit an upstream PR following internal review.

**Describe your changes**

I added a new Format `FormatMetricPointArray` which is followed by a subversion (one of `FormatMetricPoint` or `FormatMetricPointWithoutOrg`). Following this is a concatenated set of `MetricPoint` values encoded in the specified subversion.

I also added read/write functions and an iterator to decode these points in a streaming manner.

**Testing performed**

Added unit tests and performed adhoc tests. With a cap of 100 points per batch, allocation rate (at peak ingest) went from ~145MB/s to ~45MB/s and max ingest speed went from ~300k/sec to ~375k/sec. 
