### PR TITLE
Move timezone confg/utils to separate package

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/api/middleware"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/expr"
 	log "github.com/sirupsen/logrus"
 )
@@ -35,7 +36,6 @@ var (
 	minSliceSize          uint
 
 	graphiteProxy *httputil.ReverseProxy
-	timeZone      *time.Location
 )
 
 func ConfigSetup() {
@@ -76,9 +76,9 @@ func ConfigProcess() {
 	graphiteProxy = NewGraphiteProxy(u)
 
 	if timeZoneStr == "local" {
-		timeZone = time.Local
+		tz.TimeZone = time.Local
 	} else {
-		timeZone, err = time.LoadLocation(timeZoneStr)
+		tz.TimeZone, err = time.LoadLocation(timeZoneStr)
 		if err != nil {
 			log.Fatalf("API Cannot load timezone %q: %s", timeZoneStr, err.Error())
 		}

--- a/api/graphite_test.go
+++ b/api/graphite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/metrictank/cluster"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
 )
 
 func TestServer_renderMetrics_unknownFunctionError(t *testing.T) {
@@ -18,7 +19,7 @@ func TestServer_renderMetrics_unknownFunctionError(t *testing.T) {
 	defer initProxyStats()
 
 	req := models.GraphiteRender{
-		FromTo: models.FromTo{
+		FromTo: tz.FromTo{
 			From: "100",
 			To:   "200",
 			Tz:   "Europe/Madrid",
@@ -65,7 +66,7 @@ func TestServer_renderMetrics_wrongArgumentError(t *testing.T) {
 	defer initProxyStats()
 
 	req := models.GraphiteRender{
-		FromTo: models.FromTo{
+		FromTo: tz.FromTo{
 			From: "100",
 			To:   "200",
 			Tz:   "Europe/Madrid",

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/go-macaron/binding"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/idx"
 	"github.com/grafana/metrictank/schema"
 	pickle "github.com/kisielk/og-rek"
@@ -41,15 +42,8 @@ import (
 //msgp:ignore SeriesTree
 //msgp:ignore SeriesTreeItem
 
-type FromTo struct {
-	From  string `json:"from" form:"from"`
-	Until string `json:"until" form:"until"`
-	To    string `json:"to" form:"to"` // graphite uses 'until' but we allow to alternatively cause it's shorter
-	Tz    string `json:"tz" form:"tz"`
-}
-
 type GraphiteRender struct {
-	FromTo
+	tz.FromTo
 	MaxDataPoints uint32   `json:"maxDataPoints" form:"maxDataPoints" binding:"Default(800)"`
 	Targets       []string `json:"target" form:"target"`
 	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
@@ -210,7 +204,7 @@ type GraphiteTagTermsResp struct {
 }
 
 type GraphiteFind struct {
-	FromTo
+	tz.FromTo
 	Query  string `json:"query" form:"query" binding:"Required"`
 	Format string `json:"format" form:"format" binding:"In(,completer,json,treejson,msgpack,pickle)"`
 	Jsonp  string `json:"jsonp" form:"jsonp"`

--- a/api/tz/tz.go
+++ b/api/tz/tz.go
@@ -1,0 +1,53 @@
+package tz
+
+import (
+	"time"
+
+	"github.com/raintank/dur"
+)
+
+var (
+	TimeZone *time.Location
+)
+
+type FromTo struct {
+	From  string `json:"from" form:"from"`
+	Until string `json:"until" form:"until"`
+	To    string `json:"to" form:"to"` // graphite uses 'until' but we allow to alternatively cause it's shorter
+	Tz    string `json:"tz" form:"tz"`
+}
+
+func GetFromTo(ft FromTo, now time.Time, defaultFrom, defaultTo uint32) (uint32, uint32, error) {
+	loc, err := getLocation(ft.Tz)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	from := ft.From
+	to := ft.To
+	if to == "" {
+		to = ft.Until
+	}
+
+	fromUnix, err := dur.ParseDateTime(from, loc, now, defaultFrom)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	toUnix, err := dur.ParseDateTime(to, loc, now, defaultTo)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return fromUnix, toUnix, nil
+}
+
+func getLocation(desc string) (*time.Location, error) {
+	switch desc {
+	case "":
+		return TimeZone, nil
+	case "local":
+		return time.Local, nil
+	}
+	return time.LoadLocation(desc)
+}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/schema"
-	"github.com/raintank/dur"
 )
 
 type FuncLinearRegression struct {
@@ -52,35 +52,21 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	s.startTarget = context.from
 	s.endTarget = context.to
 
-	if err := s.parseSourceAt(); err != nil {
+	now := time.Now()
+	defaultFrom := uint32(now.Add(-24 * time.Hour).Unix())
+	defaultTo := uint32(now.Unix())
+	var err error
+	s.startSource, s.endSource, err = tz.GetFromTo(tz.FromTo{
+		From: s.startSourceAt,
+		To:   s.endSourceAt,
+	}, now, defaultFrom, defaultTo)
+	if err != nil {
 		return context // todo panic?
 	}
 	context.from = s.startSource
 	context.to = s.endSource
 
 	return context
-}
-
-func (s *FuncLinearRegression) parseSourceAt() error {
-	loc, err := time.LoadLocation("")
-	if err != nil {
-		return fmt.Errorf("failed to load location: %w", err)
-	}
-	now := time.Now()
-
-	defaultStartSource := uint32(now.Add(-24 * time.Hour).Unix())
-	s.startSource, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSource)
-	if err != nil {
-		return fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
-	}
-
-	defaultEndSource := uint32(now.Unix())
-	s.endSource, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSource)
-	if err != nil {
-		return fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
-	}
-
-	return nil
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {


### PR DESCRIPTION
Moves the api timezone/location utils to a new package and exports them for use in the expr package.

Definitely not an ideal solution as some encapsulation of the TimeZone global var is lost so that it can continue to be set from the api/config setup thus maintaining backwards compatibility. Unwinding the dependency of the `api` package on the `expr` package would be considerably more messy.

I'm not married to the `tz` package name.