### PR TITLE
Move timezone and utils to separate package

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/api/middleware"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/expr"
 	log "github.com/sirupsen/logrus"
 )
@@ -35,7 +36,6 @@ var (
 	minSliceSize          uint
 
 	graphiteProxy *httputil.ReverseProxy
-	timeZone      *time.Location
 )
 
 func ConfigSetup() {
@@ -76,9 +76,9 @@ func ConfigProcess() {
 	graphiteProxy = NewGraphiteProxy(u)
 
 	if timeZoneStr == "local" {
-		timeZone = time.Local
+		tz.TimeZone = time.Local
 	} else {
-		timeZone, err = time.LoadLocation(timeZoneStr)
+		tz.TimeZone, err = time.LoadLocation(timeZoneStr)
 		if err != nil {
 			log.Fatalf("API Cannot load timezone %q: %s", timeZoneStr, err.Error())
 		}

--- a/api/graphite_test.go
+++ b/api/graphite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/metrictank/cluster"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
 )
 
 func TestServer_renderMetrics_unknownFunctionError(t *testing.T) {
@@ -18,7 +19,7 @@ func TestServer_renderMetrics_unknownFunctionError(t *testing.T) {
 	defer initProxyStats()
 
 	req := models.GraphiteRender{
-		FromTo: models.FromTo{
+		FromTo: tz.FromTo{
 			From: "100",
 			To:   "200",
 			Tz:   "Europe/Madrid",
@@ -65,7 +66,7 @@ func TestServer_renderMetrics_wrongArgumentError(t *testing.T) {
 	defer initProxyStats()
 
 	req := models.GraphiteRender{
-		FromTo: models.FromTo{
+		FromTo: tz.FromTo{
 			From: "100",
 			To:   "200",
 			Tz:   "Europe/Madrid",

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/go-macaron/binding"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/idx"
 	"github.com/grafana/metrictank/schema"
 	pickle "github.com/kisielk/og-rek"
@@ -41,15 +42,8 @@ import (
 //msgp:ignore SeriesTree
 //msgp:ignore SeriesTreeItem
 
-type FromTo struct {
-	From  string `json:"from" form:"from"`
-	Until string `json:"until" form:"until"`
-	To    string `json:"to" form:"to"` // graphite uses 'until' but we allow to alternatively cause it's shorter
-	Tz    string `json:"tz" form:"tz"`
-}
-
 type GraphiteRender struct {
-	FromTo
+	tz.FromTo
 	MaxDataPoints uint32   `json:"maxDataPoints" form:"maxDataPoints" binding:"Default(800)"`
 	Targets       []string `json:"target" form:"target"`
 	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
@@ -85,14 +79,12 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteTags struct {
-	FromTo
 	Filter string `json:"filter" form:"filter"`
 }
 
 type GraphiteTagsResp []GraphiteTagResp
 
 type GraphiteAutoCompleteTags struct {
-	FromTo
 	Prefix string   `json:"tagPrefix" form:"tagPrefix"`
 	Expr   []string `json:"expr" form:"expr"`
 	Limit  uint     `json:"limit" form:"limit"`
@@ -212,7 +204,7 @@ type GraphiteTagTermsResp struct {
 }
 
 type GraphiteFind struct {
-	FromTo
+	tz.FromTo
 	Query  string `json:"query" form:"query" binding:"Required"`
 	Format string `json:"format" form:"format" binding:"In(,completer,json,treejson,msgpack,pickle)"`
 	Jsonp  string `json:"jsonp" form:"jsonp"`

--- a/tz/tz.go
+++ b/tz/tz.go
@@ -1,0 +1,53 @@
+package tz
+
+import (
+	"time"
+
+	"github.com/raintank/dur"
+)
+
+var (
+	TimeZone *time.Location
+)
+
+type FromTo struct {
+	From  string `json:"from" form:"from"`
+	Until string `json:"until" form:"until"`
+	To    string `json:"to" form:"to"` // graphite uses 'until' but we allow to alternatively cause it's shorter
+	Tz    string `json:"tz" form:"tz"`
+}
+
+func GetFromTo(ft FromTo, now time.Time, defaultFrom, defaultTo uint32) (uint32, uint32, error) {
+	loc, err := getLocation(ft.Tz)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	from := ft.From
+	to := ft.To
+	if to == "" {
+		to = ft.Until
+	}
+
+	fromUnix, err := dur.ParseDateTime(from, loc, now, defaultFrom)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	toUnix, err := dur.ParseDateTime(to, loc, now, defaultTo)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return fromUnix, toUnix, nil
+}
+
+func getLocation(desc string) (*time.Location, error) {
+	switch desc {
+	case "":
+		return TimeZone, nil
+	case "local":
+		return time.Local, nil
+	}
+	return time.LoadLocation(desc)
+}


### PR DESCRIPTION
This PR moves the `api.timeZone` var and certain utilities from the `api` package into a new `tz` package. The `GetFromTo` function is exported for use in a future native implementation of the [`linearRegression` function](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.linearRegression).

Some encapsulation of the `api.timeZone` var (now `tz.TimeZone`) is lost so that it can continue to be set from `api.ConfigSetup`, maintaining backwards compatibility. The `api` package is highly dependent on the `expr` package, making the export of `api.getFromTo` from the `api` package for use in native function implementations (the `expr` package) difficult due to import cycles.