### PR TITLE
Implement linearRegression natively

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -109,7 +109,7 @@ See also:
 | keepLastValue(seriesList, limit) seriesList                    |              | Stable     |
 | legendValue                                                    |              | No         |
 | limit                                                          |              | No         |
-| linearRegression                                               |              | No         |
+| linearRegression                                               |              | Stable     |
 | linearRegressionAnalysis                                       |              | No         |
 | lineWidth                                                      |              | No         |
 | logarithm                                                      |              | No         |

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-"fmt"
 	"math"
 	"strings"
 	"unsafe"
@@ -89,7 +88,6 @@ func aggregate(dataMap DataMap, series []models.Series, queryPatts []string, agg
 	var meta models.SeriesMeta
 
 	for _, serie := range series {
-		fmt.Println("DOM DEBUG aggregate interval:", serie.Interval)
 		meta = meta.Merge(serie.Meta)
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {
@@ -114,7 +112,6 @@ func aggregate(dataMap DataMap, series []models.Series, queryPatts []string, agg
 	output.QueryCons = queryCons
 	output.Consolidator = cons
 	output.Meta = meta
-	fmt.Println("DOM DEBUG aggregate output:", output)
 
 	dataMap.Add(Req{}, output)
 

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+"fmt"
 	"math"
 	"strings"
 	"unsafe"
@@ -88,6 +89,7 @@ func aggregate(dataMap DataMap, series []models.Series, queryPatts []string, agg
 	var meta models.SeriesMeta
 
 	for _, serie := range series {
+		fmt.Println("DOM DEBUG aggregate interval:", serie.Interval)
 		meta = meta.Merge(serie.Meta)
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {
@@ -112,6 +114,7 @@ func aggregate(dataMap DataMap, series []models.Series, queryPatts []string, agg
 	output.QueryCons = queryCons
 	output.Consolidator = cons
 	output.Meta = meta
+	fmt.Println("DOM DEBUG aggregate output:", output)
 
 	dataMap.Add(Req{}, output)
 

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -58,6 +58,13 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 	var sumV float64
 	var sumIV float64
 	for _, v := range series.Datapoints {
+		if v.Ts < startSourceAt { // todo can optimize assuming this is sorted
+			continue
+		}
+		if v.Ts > endSourceAt {
+			break
+		}
+
 		// we can't use the index from the datapoints because missing datapoints
 		// do not exist
 		// todo make this sound more better
@@ -89,12 +96,12 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	now := time.Now()
 
 	// todo this should account for empty params assuming thats how unspecified optional string args manifest
-	from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
+	startSourceAt, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
 	if err != nil {
 		return nil, err // todo wrap
 	}
 
-	to, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
+	endSourceAt, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
 	if err != nil {
 		return nil, err // todo wrap
 	}
@@ -109,7 +116,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	// these values come from the request context but we don't have access to that context in Exec..
 	results := []models.Series{}
 	for _, serie := range series {
-		factor, offset, forecast := linearRegressionAnalysis(serie, from, to)
+		factor, offset, forecast := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
 		fmt.Println("factor", factor, "offset", offset, "forecast", forecast)
 		if !forecast {
 			continue
@@ -125,12 +132,12 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			})
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, from, to)
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startSourceAt, endSourceAt)
 
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", from, to)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", startSourceAt, endSourceAt)
 		newSeries.QueryPatt = name
 		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -15,6 +15,8 @@ type FuncLinearRegression struct {
 
 	startSourceAt string
 	endSourceAt   string
+	parsedStartSourceAt uint32
+	parsedEndSourceAt uint32
 
 	startTargetAt uint32
 	endTargetAt   uint32
@@ -49,40 +51,48 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	s.startTargetAt = context.from
 	s.endTargetAt = context.to
 
+	if err := s.parseSourceAt(); err != nil {
+		fmt.Println("DOM DEBUG PARSE ERR:", err)
+	}// todo handle error
+	context.from = s.parsedStartSourceAt
+	context.to = s.parsedEndSourceAt
+
 	return context
 }
 
-func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
+func (s *FuncLinearRegression) parseSourceAt() error {
 	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
 	if err != nil {
-		return nil, fmt.Errorf("failed to load location: %w", err)
+		return fmt.Errorf("failed to load location: %w", err)
 	}
 
 	now := time.Now()
 
 	defaultStartSourceAt := uint32(now.Add(-24 * time.Hour).Unix())
-	startSourceAt, err := dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
+	s.parsedStartSourceAt, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
+		return fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
 	}
 
 	defaultEndSourceAt := uint32(now.Unix())
-	endSourceAt, err := dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
+	s.parsedEndSourceAt, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
+		return fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
 	}
 
-	// todo update context.from and .to if needed?
+	return nil
+}
 
+func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	series, err := s.in.Exec(dataMap)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("DOM DEBUG startSourceAt:", startSourceAt, "endSourceAt:", endSourceAt, "startTargetAt:", s.startTargetAt, "endTargetAt:", s.endTargetAt)
+	fmt.Println("DOM DEBUG s.parsedStartSourceAt:", s.parsedStartSourceAt, "s.parsedEndSourceAt:", s.parsedEndSourceAt, "startTargetAt:", s.startTargetAt, "endTargetAt:", s.endTargetAt)
 	results := []models.Series{}
 	for _, serie := range series {
-		factor, offset, isValid := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
+		factor, offset, isValid := linearRegressionAnalysis(serie, s.parsedStartSourceAt, s.parsedEndSourceAt)
 		if !isValid {
 			continue
 		}
@@ -90,7 +100,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - s.startTargetAt) / serie.Interval))
 		for i, _ := range serie.Datapoints {
 			datapoints = append(datapoints, schema.Point{
-				Val: offset + (float64(startSourceAt)+float64(i)*float64(serie.Interval))*factor,
+				Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
 				Ts:  s.startTargetAt + uint32(i)*serie.Interval,
 			})
 		}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -118,6 +118,8 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 
 		results = append(results, newSeries)
 	}
+
+	dataMap.Add(Req{}, results...)
 	return results, nil
 }
 

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -83,18 +83,6 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 	return nil
 }
 
-func normalize(timestamp, interval uint32) uint32 {
-	fmt.Println("DOM DEBUG timestamp:", timestamp, "interval:", interval)
-	fmt.Println("timestamp / interval:", timestamp/interval)
-	fmt.Println("timestamp / interval * interval:", timestamp/interval*interval)
-	normalized := timestamp / interval * interval
-	if normalized < timestamp {
-		normalized += interval
-	}
-
-	return normalized
-}
-
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	fmt.Println("DOM DEBUG dataMap:", dataMap)
 
@@ -107,22 +95,18 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	results := []models.Series{}
 	for _, serie := range series {
 		fmt.Println("DOM DEBUG series:", serie)
-		startTargetAt := normalize(s.startTargetAt, serie.Interval)
-		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
-		endTargetAt := normalize(s.endTargetAt, serie.Interval)
-		fmt.Println("DOM DEBUG base end target at:", s.endTargetAt, "normalized", endTargetAt)
 
-		factor, offset, isValid := linearRegressionAnalysis(serie, serie.QueryFrom)
+		factor, offset, isValid := linearRegressionAnalysis(serie)
 		if !isValid {
 			continue
 		}
 		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
-		size := (endTargetAt - startTargetAt) / serie.Interval
-		if (endTargetAt-startTargetAt)%serie.Interval == 0 {
-			size++
-		}
-		datapoints := pointSlicePool.GetMin(int(size))
+		startTargetAt := normalize(s.startTargetAt, serie.Interval)
+		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
+		endTargetAt := normalize(s.endTargetAt, serie.Interval)
+		fmt.Println("DOM DEBUG base end target at:", s.endTargetAt, "normalized", endTargetAt)
+		datapoints := pointSlicePool.GetMin(int((endTargetAt - startTargetAt) / serie.Interval))
 		for i := 0; i < int((endTargetAt-startTargetAt)/serie.Interval); i++ {
 			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor,
@@ -148,7 +132,9 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	return results, nil
 }
 
-func linearRegressionAnalysis(series models.Series, startSourceAt uint32) (float64, float64, bool) {
+func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
+	startSourceAt := series.QueryFrom // todo check if this is still needed
+	// i think this was because the sumseries didnt normalize this properly
 	if len(series.Datapoints) > 0 {
 		startSourceAt = series.Datapoints[0].Ts
 	}
@@ -182,4 +168,16 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32) (float
 	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
 	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
 	return factor, offset, true
+}
+
+func normalize(timestamp, interval uint32) uint32 {
+	fmt.Println("DOM DEBUG timestamp:", timestamp, "interval:", interval)
+	fmt.Println("timestamp / interval:", timestamp/interval)
+	fmt.Println("timestamp / interval * interval:", timestamp/interval*interval)
+	normalized := timestamp / interval * interval
+	if normalized < timestamp {
+		normalized += interval
+	}
+
+	return normalized
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -67,14 +67,14 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 	}
 	now := time.Now()
 
-	defaultStartSourceAt := uint32(now.Add(-24 * time.Hour).Unix())
-	s.startSource, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
+	defaultStartSource := uint32(now.Add(-24 * time.Hour).Unix())
+	s.startSource, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSource)
 	if err != nil {
 		return fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
 	}
 
-	defaultEndSourceAt := uint32(now.Unix())
-	s.endSource, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
+	defaultEndSource := uint32(now.Unix())
+	s.endSource, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSource)
 	if err != nil {
 		return fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
 	}
@@ -95,13 +95,13 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		startTarget := normalize(s.startTarget, serie.Interval)
-		size := int((s.endTarget-startTarget)/serie.Interval + 1)
+		normalizedStartTarget := normalize(s.startTarget, serie.Interval)
+		size := int((s.endTarget-normalizedStartTarget)/serie.Interval + 1)
 		datapoints := pointSlicePool.GetMin(size)
 		for i := 0; i < size; i++ {
 			datapoint := schema.Point{
-				Val: offset + (float64(startTarget)+float64(i)*float64(serie.Interval))*factor,
-				Ts:  startTarget + uint32(i)*serie.Interval,
+				Val: offset + (float64(normalizedStartTarget)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  normalizedStartTarget + uint32(i)*serie.Interval,
 			}
 			datapoints = append(datapoints, datapoint)
 		}
@@ -122,10 +122,10 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 }
 
 func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
-	startSourceAt := series.QueryFrom // todo check if this is still needed
+	startSource := series.QueryFrom // todo check if this is still needed
 	// i think this was because the sumseries didnt normalize this properly
 	if len(series.Datapoints) > 0 {
-		startSourceAt = series.Datapoints[0].Ts
+		startSource = series.Datapoints[0].Ts
 	}
 
 	var n float64
@@ -150,7 +150,7 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 		return 0, 0, false
 	}
 	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
-	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
+	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSource)
 
 	return factor, offset, true
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -111,8 +111,8 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	results := []models.Series{}
 	for _, serie := range series {
-		factor, offset, forecast := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
-		if !forecast {
+		factor, offset, isValid := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
+		if !isValid {
 			continue
 		}
 

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -96,8 +96,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		startTargetAt := normalize(s.startTargetAt, serie.Interval)
-		endTargetAt := normalize(s.endTargetAt, serie.Interval)
-		size := int((endTargetAt - startTargetAt) / serie.Interval)
+		size := int((s.endTargetAt-startTargetAt)/serie.Interval + 1)
 
 		datapoints := pointSlicePool.GetMin(size)
 		for i := 0; i < size; i++ {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -54,8 +54,8 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	if err := s.parseSourceAt(); err != nil {
 		fmt.Println("DOM DEBUG PARSE ERR:", err)
 	}// todo handle error
-	//context.from = s.parsedStartSourceAt
-	//context.to = s.parsedEndSourceAt
+	context.from = s.parsedStartSourceAt
+	context.to = s.parsedEndSourceAt
 
 	return context
 }
@@ -96,6 +96,8 @@ func normalize(timestamp, interval uint32) uint32 {
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
+	fmt.Println("DOM DEBUG dataMap:", dataMap)
+
 	series, err := s.in.Exec(dataMap)
 	if err != nil {
 		return nil, err
@@ -110,14 +112,15 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		startTargetAt := normalize(s.startTargetAt, deducedInterval)
 		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
 
-		factor, offset, isValid := linearRegressionAnalysis(serie, startTargetAt)
+		factor, offset, isValid := linearRegressionAnalysis(serie, serie.QueryFrom)
 		if !isValid {
 			continue
 		}
 		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
 		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - startTargetAt) / deducedInterval))
-		for i, _ := range serie.Datapoints {
+                //for i := 0; i < int((s.endTargetAt - startTargetAt) / deducedInterval); i++ {
+		for i := 0; i < len(serie.Datapoints); i++ {
 			fmt.Println("startTargetAt:", startTargetAt, "i:", i)
 			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,
@@ -127,12 +130,12 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			datapoints = append(datapoints, datapoint)
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startTargetAt, s.endTargetAt)
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.parsedStartSourceAt, s.parsedEndSourceAt)
 
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startTargetAt, s.endTargetAt)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.parsedStartSourceAt, s.parsedEndSourceAt)
 		newSeries.QueryPatt = name
 		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt
@@ -152,6 +155,10 @@ func deduceInterval(series models.Series) uint32 {
 }
 
 func linearRegressionAnalysis(series models.Series, startSourceAt uint32) (float64, float64, bool) {
+	if len(series.Datapoints) > 0 {
+		startSourceAt = series.Datapoints[0].Ts
+	}
+
 	var n float64
 	var sumI float64
 	var sumII float64

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -83,6 +83,18 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 	return nil
 }
 
+func normalize(timestamp, interval uint32) uint32 {
+	fmt.Println("DOM DEBUG timestamp:", timestamp, "interval:", interval)
+	fmt.Println("timestamp / interval:", timestamp / interval)
+	fmt.Println("timestamp / interval * interval:", timestamp / interval * interval)
+	normalized := timestamp / interval * interval
+	if normalized < timestamp {
+		normalized += interval
+	}
+
+	return normalized
+}
+
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	series, err := s.in.Exec(dataMap)
 	if err != nil {
@@ -92,32 +104,46 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	fmt.Println("DOM DEBUG s.parsedStartSourceAt:", s.parsedStartSourceAt, "s.parsedEndSourceAt:", s.parsedEndSourceAt, "startTargetAt:", s.startTargetAt, "endTargetAt:", s.endTargetAt)
 	results := []models.Series{}
 	for _, serie := range series {
+		fmt.Println("DOM DEBUG series:", serie)
 		factor, offset, isValid := linearRegressionAnalysis(serie, s.parsedStartSourceAt, s.parsedEndSourceAt)
 		if !isValid {
 			continue
 		}
 
-		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - s.startTargetAt) / serie.Interval))
+		deducedInterval := deduceInterval(serie)
+		fmt.Println("DOM DEBUG acutal interval:", serie.Interval, "deduced:", deducedInterval)
+		startTargetAt := normalize(s.startTargetAt, deducedInterval)
+		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
+
+		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - startTargetAt) / deducedInterval))
 		for i, _ := range serie.Datapoints {
 			datapoints = append(datapoints, schema.Point{
-				Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
-				Ts:  s.startTargetAt + uint32(i)*serie.Interval,
+				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,
+				Ts:  startTargetAt + uint32(i)*deducedInterval,
 			})
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startTargetAt, s.endTargetAt)
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startTargetAt, s.endTargetAt)
 
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startTargetAt, s.endTargetAt)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", startTargetAt, s.endTargetAt)
 		newSeries.QueryPatt = name
-		newSeries.QueryFrom = s.startTargetAt
+		newSeries.QueryFrom = startTargetAt
 		newSeries.QueryTo = s.endTargetAt
 
 		results = append(results, newSeries)
 	}
 	return results, nil
+}
+
+func deduceInterval(series models.Series) uint32 {
+	if len(series.Datapoints) < 2 {
+		return 0
+	}
+
+	return series.Datapoints[1].Ts - series.Datapoints[0].Ts
 }
 
 func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -61,7 +61,7 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 }
 
 func (s *FuncLinearRegression) parseSourceAt() error {
-	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
+	loc, err := time.LoadLocation("")
 	if err != nil {
 		return fmt.Errorf("failed to load location: %w", err)
 	}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -1,21 +1,20 @@
 package expr
 
 import (
-	//"time"
 	"fmt"
+	"time"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
-	//"github.com/raintank/dur"
+	"github.com/raintank/dur"
 )
 
 type FuncLinearRegression struct {
 	in            GraphiteFunc
 	startSourceAt string
 	endSourceAt   string
-
-	start uint32
-	end uint32
+	startTargetAt uint32
+	endTargetAt   uint32
 }
 
 func NewLinearRegression() GraphiteFunc {
@@ -44,13 +43,14 @@ func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
 }
 
 func (s *FuncLinearRegression) Context(context Context) Context {
-	s.start = context.from
-	s.end = context.to 
+	// im assuming from/to correspond to the python startTime/endTime here
+	s.startTargetAt = context.from
+	s.endTargetAt = context.to
 
 	return context
 }
 
-func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
+func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {
 	n := float64(len(series.Datapoints))
 
 	var sumI float64
@@ -58,14 +58,14 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 	var sumV float64
 	var sumIV float64
 	for _, v := range series.Datapoints {
-			// we can't use the index from the datapoints because missing datapoints
-			// do not exist
-			// todo make this sound more better
-			i := (v.Ts - series.QueryFrom) / series.Interval
-			sumI += float64(i)
-			sumII += float64(i) * float64(i)
-			sumV += v.Val
-			sumIV += float64(i) * v.Val
+		// we can't use the index from the datapoints because missing datapoints
+		// do not exist
+		// todo make this sound more better
+		i := (v.Ts - series.QueryFrom) / series.Interval
+		sumI += float64(i)
+		sumII += float64(i) * float64(i)
+		sumV += v.Val
+		sumIV += float64(i) * v.Val
 	}
 	fmt.Println("sumI", sumI, "sumII", sumII, "sumV", sumV, "sumIV", sumIV)
 
@@ -81,7 +81,7 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
-	/*loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
+	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
 	if err != nil {
 		return nil, err // todo wrap
 	}
@@ -89,7 +89,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	now := time.Now()
 
 	// todo this should account for empty params assuming thats how unspecified optional string args manifest
-	/*from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
+	from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
 	if err != nil {
 		return nil, err // todo wrap
 	}
@@ -97,7 +97,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	to, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
 	if err != nil {
 		return nil, err // todo wrap
-	}*/// todo pass these into the linear regression function since that series might have more data than what we want to poll from
+	}
 
 	// todo update context.from and .to if needed?
 
@@ -109,35 +109,36 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	// these values come from the request context but we don't have access to that context in Exec..
 	results := []models.Series{}
 	for _, serie := range series {
-		factor, offset, forecast := linearRegressionAnalysis(serie)
+		factor, offset, forecast := linearRegressionAnalysis(serie, from, to)
 		fmt.Println("factor", factor, "offset", offset, "forecast", forecast)
 		if !forecast {
 			continue
 		}
 
-		fmt.Println("size", (s.end - s.start) / serie.Interval)
-		datapoints := []schema.Point{}//make([]schema.Point, (s.end - s.start) / serie.Interval)
+		fmt.Println("size", (s.endTargetAt-s.startTargetAt)/serie.Interval)
+		datapoints := []schema.Point{} //make([]schema.Point, (s.endTargetAt - s.startTargetAt) / serie.Interval)
 		var i uint32
-		for i = 0; i <= (s.end - s.start) / serie.Interval; i++ {//for i, _ := range serie.Datapoints {
+		for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {
 			datapoints = append(datapoints, schema.Point{
-				Val: offset + (float64(s.start) + float64(i) * float64(serie.Interval)) * factor,
-				Ts: s.start + i * serie.Interval,
+				Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  s.startTargetAt + i*serie.Interval,
 			})
 		}
 
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, from, to)
 		newSeries := models.Series{
-			Target: "todo",
-			Tags: map[string]string{},
-			Interval: serie.Interval,
-			QueryPatt: "todo",
-			QueryFrom: s.start,
-			QueryTo: s.end,
-			QueryCons: serie.QueryCons,
+			Target:       name,
+			Tags:         map[string]string{},
+			Interval:     serie.Interval,
+			QueryPatt:    name,
+			QueryFrom:    s.startTargetAt,
+			QueryTo:      s.endTargetAt,
+			QueryCons:    serie.QueryCons,
 			Consolidator: serie.Consolidator,
-			QueryMDP: serie.QueryMDP,
+			QueryMDP:     serie.QueryMDP,
 			QueryPNGroup: serie.QueryPNGroup,
-			Meta: serie.Meta,
-			Datapoints: datapoints,
+			Meta:         serie.Meta,
+			Datapoints:   datapoints,
 		}
 
 		results = append(results, newSeries)

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -85,20 +85,21 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
 	if err != nil {
-		return nil, err // todo wrap
+		return nil, fmt.Errorf("failed to load location: %w", err)
 	}
 
 	now := time.Now()
 
-	// todo this should account for empty params assuming thats how unspecified optional string args manifest
-	startSourceAt, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
+	defaultStartSourceAt := uint32(now.Add(-24 * time.Hour).Unix())
+	startSourceAt, err := dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
 	if err != nil {
-		return nil, err // todo wrap
+		return nil, fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
 	}
 
-	endSourceAt, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
+	defaultEndSourceAt := uint32(now.Unix())
+	endSourceAt, err := dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
 	if err != nil {
-		return nil, err // todo wrap
+		return nil, fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
 	}
 
 	// todo update context.from and .to if needed?
@@ -108,7 +109,6 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		return nil, err
 	}
 
-	// these values come from the request context but we don't have access to that context in Exec..
 	results := []models.Series{}
 	for _, serie := range series {
 		factor, offset, forecast := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
@@ -117,15 +117,18 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		datapoints := []schema.Point{}
-		var i uint32
-		for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {
-			datapoints = append(datapoints, schema.Point{
-				Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
-				Ts:  s.startTargetAt + i*serie.Interval,
-			})
+		{
+			var i uint32
+			for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {
+				datapoints = append(datapoints, schema.Point{
+					Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
+					Ts:  s.startTargetAt + i*serie.Interval,
+				})
+			}
 		}
 
 		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startSourceAt, endSourceAt)
+
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
@@ -135,6 +138,5 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		newSeries.QueryTo = s.endTargetAt
 		results = append(results, newSeries)
 	}
-
 	return results, nil
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -11,9 +11,11 @@ import (
 )
 
 type FuncLinearRegression struct {
-	in            GraphiteFunc
+	in GraphiteFunc
+
 	startSourceAt string
 	endSourceAt   string
+
 	startTargetAt uint32
 	endTargetAt   uint32
 }
@@ -59,14 +61,15 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 	var sumIV float64
 
 	for i := sort.Search(len(series.Datapoints), func(i int) bool { return series.Datapoints[i].Ts >= startSourceAt }); i < len(series.Datapoints) && series.Datapoints[i].Ts <= endSourceAt; i++ {
-		// we can't use the index from the datapoints because missing datapoints
-		// do not exist
-		// todo make this sound more better
-		index := (series.Datapoints[i].Ts - series.QueryFrom) / series.Interval
-		sumI += float64(index)
-		sumII += float64(index) * float64(index)
-		sumV += series.Datapoints[i].Val
-		sumIV += float64(index) * series.Datapoints[i].Val
+		// The index must be rebuilt from the timestamp because
+		// the points of the series do not include "missing" points.
+		index := float64((series.Datapoints[i].Ts - startSourceAt) / series.Interval)
+		value := series.Datapoints[i].Val
+
+		sumI += index
+		sumII += index * index
+		sumV += value
+		sumIV += index * value
 	}
 
 	denominator := n*sumII - sumI*sumI
@@ -74,8 +77,8 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 		return 0, 0, false
 	}
 
-	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)         // todo double check interval is correct to use here
-	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(series.QueryFrom) // todo double check queryfrom is correct to use here
+	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
+	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
 	return factor, offset, true
 }
 

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -111,6 +111,8 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		fmt.Println("DOM DEBUG acutal interval:", serie.Interval, "deduced:", deducedInterval)
 		startTargetAt := normalize(s.startTargetAt, deducedInterval)
 		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
+		endTargetAt := normalize(s.endTargetAt, deducedInterval)
+		fmt.Println("DOM DEBUG base end target at:", s.endTargetAt, "normalized", endTargetAt)
 
 		factor, offset, isValid := linearRegressionAnalysis(serie, serie.QueryFrom)
 		if !isValid {
@@ -118,9 +120,9 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
-		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - startTargetAt) / deducedInterval))
+		datapoints := pointSlicePool.GetMin(int((endTargetAt - startTargetAt) / deducedInterval))
                 //for i := 0; i < int((s.endTargetAt - startTargetAt) / deducedInterval); i++ {
-		for i := 0; i < len(serie.Datapoints); i++ {
+		for i := 0; i < int((endTargetAt - startTargetAt) / deducedInterval); i++ {
 			fmt.Println("startTargetAt:", startTargetAt, "i:", i)
 			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -122,8 +122,9 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 }
 
 func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
-	startSource := series.QueryFrom // todo check if this is still needed
-	// i think this was because the sumseries didnt normalize this properly
+	// Some functions normalize the series' datapoint timestamps,
+	// but not the series' QueryFrom/QueryTo fields.
+	startSource := series.QueryFrom
 	if len(series.Datapoints) > 0 {
 		startSource = series.Datapoints[0].Ts
 	}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -126,20 +126,14 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, from, to)
-		newSeries := models.Series{
-			Target:       name,
-			Tags:         map[string]string{},
-			Interval:     serie.Interval,
-			QueryPatt:    name,
-			QueryFrom:    s.startTargetAt,
-			QueryTo:      s.endTargetAt,
-			QueryCons:    serie.QueryCons,
-			Consolidator: serie.Consolidator,
-			QueryMDP:     serie.QueryMDP,
-			QueryPNGroup: serie.QueryPNGroup,
-			Meta:         serie.Meta,
-			Datapoints:   datapoints,
-		}
+
+		newSeries := serie.Copy([]schema.Point{})
+		newSeries.Target = name
+		newSeries.Datapoints = datapoints
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", from, to)
+		newSeries.QueryPatt = name
+		newSeries.QueryFrom = s.startTargetAt
+		newSeries.QueryTo = s.endTargetAt
 
 		results = append(results, newSeries)
 	}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -52,8 +52,8 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	s.endTargetAt = context.to
 
 	if err := s.parseSourceAt(); err != nil {
-		fmt.Println("DOM DEBUG PARSE ERR:", err)
-	} // todo handle error
+		return context // todo panic?
+	}
 	context.from = s.parsedStartSourceAt
 	context.to = s.parsedEndSourceAt
 
@@ -65,7 +65,6 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 	if err != nil {
 		return fmt.Errorf("failed to load location: %w", err)
 	}
-
 	now := time.Now()
 
 	defaultStartSourceAt := uint32(now.Add(-24 * time.Hour).Unix())
@@ -84,49 +83,39 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
-	fmt.Println("DOM DEBUG dataMap:", dataMap)
-
 	series, err := s.in.Exec(dataMap)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("DOM DEBUG s.parsedStartSourceAt:", s.parsedStartSourceAt, "s.parsedEndSourceAt:", s.parsedEndSourceAt, "startTargetAt:", s.startTargetAt, "endTargetAt:", s.endTargetAt)
 	results := []models.Series{}
 	for _, serie := range series {
-		fmt.Println("DOM DEBUG series:", serie)
-
 		factor, offset, isValid := linearRegressionAnalysis(serie)
 		if !isValid {
 			continue
 		}
-		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
 		startTargetAt := normalize(s.startTargetAt, serie.Interval)
-		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
 		endTargetAt := normalize(s.endTargetAt, serie.Interval)
-		fmt.Println("DOM DEBUG base end target at:", s.endTargetAt, "normalized", endTargetAt)
-		datapoints := pointSlicePool.GetMin(int((endTargetAt - startTargetAt) / serie.Interval))
-		for i := 0; i < int((endTargetAt-startTargetAt)/serie.Interval); i++ {
+		size := int((endTargetAt - startTargetAt) / serie.Interval)
+
+		datapoints := pointSlicePool.GetMin(size)
+		for i := 0; i < size; i++ {
 			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor,
 				Ts:  startTargetAt + uint32(i)*serie.Interval,
 			}
-			fmt.Println("DOM DEBUG:", offset, "+ (", startTargetAt, "+", i, "*", serie.Interval, ") *", factor, "=", offset+(float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor, "=", datapoint.Val, "@", datapoint.Ts)
 			datapoints = append(datapoints, datapoint)
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.parsedStartSourceAt, s.parsedEndSourceAt)
-
 		newSeries := serie.Copy([]schema.Point{})
-		newSeries.Target = name
+		newSeries.Target = fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.parsedStartSourceAt, s.parsedEndSourceAt)
 		newSeries.Datapoints = datapoints
 		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.parsedStartSourceAt, s.parsedEndSourceAt)
-		newSeries.QueryPatt = name
+		newSeries.QueryPatt = newSeries.Target
 		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt
 
-		fmt.Println("newSeries:", newSeries)
 		results = append(results, newSeries)
 	}
 	return results, nil
@@ -144,8 +133,6 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 	var sumII float64
 	var sumV float64
 	var sumIV float64
-
-	fmt.Println("DOM DEBUG series.Interval:", series.Interval, "startSourceAt:", startSourceAt)
 	for i, point := range series.Datapoints {
 		if math.IsNaN(point.Val) {
 			continue
@@ -157,23 +144,18 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 		sumV += point.Val
 		sumIV += float64(i) * point.Val
 	}
-	fmt.Println("DOM DEBUG n:", n, "sumI:", sumI, "sumV:", sumV, "sumII:", sumII, "sumIV:", sumIV)
 
 	denominator := n*sumII - sumI*sumI
-	fmt.Println("DOM DEBUG denominator:", denominator)
 	if denominator == 0 {
 		return 0, 0, false
 	}
-
 	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
 	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
+
 	return factor, offset, true
 }
 
 func normalize(timestamp, interval uint32) uint32 {
-	fmt.Println("DOM DEBUG timestamp:", timestamp, "interval:", interval)
-	fmt.Println("timestamp / interval:", timestamp/interval)
-	fmt.Println("timestamp / interval * interval:", timestamp/interval*interval)
 	normalized := timestamp / interval * interval
 	if normalized < timestamp {
 		normalized += interval

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -3,7 +3,6 @@ package expr
 import (
 	"fmt"
 	"math"
-	"sort"
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
@@ -53,35 +52,6 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	return context
 }
 
-func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {
-	var n float64
-	var sumI float64
-	var sumII float64
-	var sumV float64
-	var sumIV float64
-
-	for i := sort.Search(len(series.Datapoints), func(i int) bool { return series.Datapoints[i].Ts >= startSourceAt }); i < len(series.Datapoints) && series.Datapoints[i].Ts <= endSourceAt; i++ {
-		if math.IsNaN(series.Datapoints[i].Val) {
-			continue
-		}
-
-		n++
-		sumI += float64(i)
-		sumII += float64(i) * float64(i)
-		sumV += series.Datapoints[i].Val
-		sumIV += float64(i) * series.Datapoints[i].Val
-	}
-
-	denominator := n*sumII - sumI*sumI
-	if denominator == 0 {
-		return 0, 0, false
-	}
-
-	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
-	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
-	return factor, offset, true
-}
-
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
 	if err != nil {
@@ -109,6 +79,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		return nil, err
 	}
 
+	fmt.Println("DOM DEBUG startSourceAt:", startSourceAt, "endSourceAt:", endSourceAt, "startTargetAt:", s.startTargetAt, "endTargetAt:", s.endTargetAt)
 	results := []models.Series{}
 	for _, serie := range series {
 		factor, offset, isValid := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
@@ -117,26 +88,54 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - s.startTargetAt) / serie.Interval))
-		{
-			var i uint32
-			for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {
-				datapoints = append(datapoints, schema.Point{
-					Val: offset + (float64(s.startTargetAt)+float64(i)*float64(serie.Interval))*factor,
-					Ts:  s.startTargetAt + i*serie.Interval,
-				})
-			}
+		for i, _ := range serie.Datapoints {
+			datapoints = append(datapoints, schema.Point{
+				Val: offset + (float64(startSourceAt)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  s.startTargetAt + uint32(i)*serie.Interval,
+			})
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startSourceAt, endSourceAt)
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startTargetAt, s.endTargetAt)
 
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", startSourceAt, endSourceAt)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startTargetAt, s.endTargetAt)
 		newSeries.QueryPatt = name
 		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt
+
 		results = append(results, newSeries)
 	}
 	return results, nil
+}
+
+func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {
+	var n float64
+	var sumI float64
+	var sumII float64
+	var sumV float64
+	var sumIV float64
+
+	for i, point := range series.Datapoints {
+		if math.IsNaN(point.Val) {
+			continue
+		}
+
+		n++
+		sumI += float64(i)
+		sumII += float64(i) * float64(i)
+		sumV += point.Val
+		sumIV += float64(i) * point.Val
+	}
+
+	denominator := n*sumII - sumI*sumI
+	if denominator == 0 {
+		return 0, 0, false
+	}
+
+	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
+	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
+	fmt.Println("DOM DEBUG sumI:", sumI, "sumII:", sumII, "sumV", sumV, "sumIV", sumIV, "factor:", factor, "offset:", offset)
+	return factor, offset, true
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/schema"
-	"github.com/raintank/dur"
 )
 
 type FuncLinearRegression struct {
@@ -52,35 +52,21 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	s.startTarget = context.from
 	s.endTarget = context.to
 
-	if err := s.parseSourceAt(); err != nil {
+	now := time.Now()
+	defaultFrom := uint32(now.Add(-24 * time.Hour).Unix())
+	defaultTo := uint32(now.Unix())
+	var err error
+	s.startSource, s.endSource, err = tz.GetFromTo(tz.FromTo{
+		From: s.startSourceAt,
+		To:   s.endSourceAt,
+	}, now, defaultFrom, defaultTo)
+	if err != nil {
 		return context // todo panic?
 	}
 	context.from = s.startSource
 	context.to = s.endSource
 
 	return context
-}
-
-func (s *FuncLinearRegression) parseSourceAt() error {
-	loc, err := time.LoadLocation("")
-	if err != nil {
-		return fmt.Errorf("failed to load location: %w", err)
-	}
-	now := time.Now()
-
-	defaultStartSource := uint32(now.Add(-24 * time.Hour).Unix())
-	s.startSource, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSource)
-	if err != nil {
-		return fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
-	}
-
-	defaultEndSource := uint32(now.Unix())
-	s.endSource, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSource)
-	if err != nil {
-		return fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
-	}
-
-	return nil
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -14,7 +14,7 @@ import (
 type FuncLinearRegression struct {
 	in GraphiteFunc
 
-	startSourceAt string // at(1) format
+	startSourceAt string // render time format
 	endSourceAt   string
 	startSource   uint32 // epoch seconds
 	endSource     uint32

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -53,8 +53,7 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 }
 
 func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {
-	n := float64(len(series.Datapoints))
-
+	var n float64
 	var sumI float64
 	var sumII float64
 	var sumV float64
@@ -66,6 +65,7 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 		index := float64((series.Datapoints[i].Ts - startSourceAt) / series.Interval)
 		value := series.Datapoints[i].Val
 
+		n++
 		sumI += index
 		sumII += index * index
 		sumV += value

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -1,0 +1,142 @@
+package expr
+
+import (
+	"time"
+	"fmt"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+	"github.com/raintank/dur"
+)
+
+type FuncLinearRegression struct {
+	in            GraphiteFunc
+	startSourceAt string
+	endSourceAt   string
+}
+
+func NewLinearRegression() GraphiteFunc {
+	return &FuncLinearRegression{}
+}
+
+func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
+	return []Arg{
+			ArgSeriesList{
+				val: &s.in,
+			},
+			ArgString{
+				key:       "startSourceAt",
+				opt:       true,
+				validator: []Validator{IsATTime},
+				val:       &s.startSourceAt,
+			},
+			ArgString{
+				key:       "endSourceAt",
+				opt:       true,
+				validator: []Validator{IsATTime},
+				val:       &s.endSourceAt,
+			},
+		},
+		[]Arg{ArgSeriesList{}}
+}
+
+func (s *FuncLinearRegression) Context(context Context) Context {
+	return context
+}
+
+func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
+	n := float64(len(series.Datapoints))
+
+	var sumI float64
+	var sumII float64
+	var sumV float64
+	var sumIV float64
+	for _, v := range series.Datapoints {
+			// we can't use the index from the datapoints because missing datapoints
+			// do not exist
+			// todo make this sound more better
+			i := (v.Ts - series.QueryFrom) / series.Interval
+			sumI += float64(i)
+			sumII += float64(i) * float64(i)
+			sumV += v.Val
+			sumIV += float64(i) * v.Val
+	}
+	fmt.Println("sumI", sumI, "sumII", sumII, "sumV", sumV, "sumIV", sumIV)
+
+	denominator := n*sumII - sumI*sumI
+	if denominator == 0 {
+		return 0, 0, false
+	}
+	fmt.Println("denominator", denominator)
+
+	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)         // todo double check interval is correct to use here
+	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(series.QueryFrom) // todo double check queryfrom is correct to use here
+	return factor, offset, true
+}
+
+func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
+	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
+	if err != nil {
+		return nil, err // todo wrap
+	}
+
+	now := time.Now()
+
+	// todo this should account for empty params assuming thats how unspecified optional string args manifest
+	from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
+	if err != nil {
+		return nil, err // todo wrap
+	}
+
+	to, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
+	if err != nil {
+		return nil, err // todo wrap
+	}
+
+	// todo update context.from and .to if needed?
+
+	series, err := s.in.Exec(dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	var start uint32 = 1200
+	var end uint32 = 1500
+	results := []models.Series{}
+	for _, serie := range series {
+		factor, offset, forecast := linearRegressionAnalysis(serie)
+		fmt.Println("factor", factor, "offset", offset, "forecast", forecast)
+		if !forecast {
+			continue
+		}
+
+		fmt.Println("size", (end - start) / serie.Interval)
+		datapoints := []schema.Point{}//make([]schema.Point, (end - start) / serie.Interval)
+		var i uint32
+		for i = 0; i <= (end - start) / serie.Interval; i++ {//for i, _ := range serie.Datapoints {
+			datapoints = append(datapoints, schema.Point{
+				Val: offset + (float64(start) + float64(i) * float64(serie.Interval)) * factor,
+				Ts: start + i * serie.Interval,
+			})
+		}
+
+		newSeries := models.Series{
+			Target: "todo",
+			Tags: map[string]string{},
+			Interval: serie.Interval,
+			QueryPatt: "todo",
+			QueryFrom: from,
+			QueryTo: to,
+			QueryCons: serie.QueryCons,
+			Consolidator: serie.Consolidator,
+			QueryMDP: serie.QueryMDP,
+			QueryPNGroup: serie.QueryPNGroup,
+			Meta: serie.Meta,
+			Datapoints: datapoints,
+		}
+
+		results = append(results, newSeries)
+	}
+
+	return results, nil
+}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -13,10 +13,10 @@ import (
 type FuncLinearRegression struct {
 	in GraphiteFunc
 
-	startSourceAt string
-	endSourceAt   string
+	startSourceAt       string
+	endSourceAt         string
 	parsedStartSourceAt uint32
-	parsedEndSourceAt uint32
+	parsedEndSourceAt   uint32
 
 	startTargetAt uint32
 	endTargetAt   uint32
@@ -53,7 +53,7 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 
 	if err := s.parseSourceAt(); err != nil {
 		fmt.Println("DOM DEBUG PARSE ERR:", err)
-	}// todo handle error
+	} // todo handle error
 	context.from = s.parsedStartSourceAt
 	context.to = s.parsedEndSourceAt
 
@@ -85,8 +85,8 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 
 func normalize(timestamp, interval uint32) uint32 {
 	fmt.Println("DOM DEBUG timestamp:", timestamp, "interval:", interval)
-	fmt.Println("timestamp / interval:", timestamp / interval)
-	fmt.Println("timestamp / interval * interval:", timestamp / interval * interval)
+	fmt.Println("timestamp / interval:", timestamp/interval)
+	fmt.Println("timestamp / interval * interval:", timestamp/interval*interval)
 	normalized := timestamp / interval * interval
 	if normalized < timestamp {
 		normalized += interval
@@ -107,11 +107,9 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	results := []models.Series{}
 	for _, serie := range series {
 		fmt.Println("DOM DEBUG series:", serie)
-		deducedInterval := deduceInterval(serie)
-		fmt.Println("DOM DEBUG acutal interval:", serie.Interval, "deduced:", deducedInterval)
-		startTargetAt := normalize(s.startTargetAt, deducedInterval)
+		startTargetAt := normalize(s.startTargetAt, serie.Interval)
 		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
-		endTargetAt := normalize(s.endTargetAt, deducedInterval)
+		endTargetAt := normalize(s.endTargetAt, serie.Interval)
 		fmt.Println("DOM DEBUG base end target at:", s.endTargetAt, "normalized", endTargetAt)
 
 		factor, offset, isValid := linearRegressionAnalysis(serie, serie.QueryFrom)
@@ -120,17 +118,17 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
-		size := (endTargetAt - startTargetAt) / deducedInterval
-		if (endTargetAt - startTargetAt) % deducedInterval == 0 {
+		size := (endTargetAt - startTargetAt) / serie.Interval
+		if (endTargetAt-startTargetAt)%serie.Interval == 0 {
 			size++
 		}
 		datapoints := pointSlicePool.GetMin(int(size))
-                for i := 0; i < int((endTargetAt - startTargetAt) / deducedInterval); i++ {
+		for i := 0; i < int((endTargetAt-startTargetAt)/serie.Interval); i++ {
 			datapoint := schema.Point{
-				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,
-				Ts:  startTargetAt + uint32(i)*deducedInterval,
+				Val: offset + (float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  startTargetAt + uint32(i)*serie.Interval,
 			}
-			fmt.Println("DOM DEBUG:", offset, "+ (", startTargetAt, "+", i, "*", deducedInterval, ") *", factor, "=", offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor, "=", datapoint.Val, "@", datapoint.Ts)
+			fmt.Println("DOM DEBUG:", offset, "+ (", startTargetAt, "+", i, "*", serie.Interval, ") *", factor, "=", offset+(float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor, "=", datapoint.Val, "@", datapoint.Ts)
 			datapoints = append(datapoints, datapoint)
 		}
 
@@ -148,14 +146,6 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		results = append(results, newSeries)
 	}
 	return results, nil
-}
-
-func deduceInterval(series models.Series) uint32 {
-	if len(series.Datapoints) < 2 {
-		return 0
-	}
-
-	return series.Datapoints[1].Ts - series.Datapoints[0].Ts
 }
 
 func linearRegressionAnalysis(series models.Series, startSourceAt uint32) (float64, float64, bool) {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -116,7 +116,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		datapoints := []schema.Point{}
+		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - s.startTargetAt) / serie.Interval))
 		{
 			var i uint32
 			for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -13,13 +13,13 @@ import (
 type FuncLinearRegression struct {
 	in GraphiteFunc
 
-	startSourceAt       string
-	endSourceAt         string
-	parsedStartSourceAt uint32
-	parsedEndSourceAt   uint32
+	startSourceAt string // at(1) format
+	endSourceAt   string
+	startSource   uint32 // epoch seconds
+	endSource     uint32
 
-	startTargetAt uint32
-	endTargetAt   uint32
+	startTarget uint32 // epoch seconds
+	endTarget   uint32
 }
 
 func NewLinearRegression() GraphiteFunc {
@@ -48,14 +48,14 @@ func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
 }
 
 func (s *FuncLinearRegression) Context(context Context) Context {
-	s.startTargetAt = context.from
-	s.endTargetAt = context.to
+	s.startTarget = context.from
+	s.endTarget = context.to
 
 	if err := s.parseSourceAt(); err != nil {
 		return context // todo panic?
 	}
-	context.from = s.parsedStartSourceAt
-	context.to = s.parsedEndSourceAt
+	context.from = s.startSource
+	context.to = s.endSource
 
 	return context
 }
@@ -68,13 +68,13 @@ func (s *FuncLinearRegression) parseSourceAt() error {
 	now := time.Now()
 
 	defaultStartSourceAt := uint32(now.Add(-24 * time.Hour).Unix())
-	s.parsedStartSourceAt, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
+	s.startSource, err = dur.ParseDateTime(s.startSourceAt, loc, now, defaultStartSourceAt)
 	if err != nil {
 		return fmt.Errorf("failed to parse 'startSourceAt' argument %q: %w", s.startSourceAt, err)
 	}
 
 	defaultEndSourceAt := uint32(now.Unix())
-	s.parsedEndSourceAt, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
+	s.endSource, err = dur.ParseDateTime(s.endSourceAt, loc, now, defaultEndSourceAt)
 	if err != nil {
 		return fmt.Errorf("failed to parse 'endSourceAt' argument %q: %w", s.endSourceAt, err)
 	}
@@ -95,25 +95,24 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		startTargetAt := normalize(s.startTargetAt, serie.Interval)
-		size := int((s.endTargetAt-startTargetAt)/serie.Interval + 1)
-
+		startTarget := normalize(s.startTarget, serie.Interval)
+		size := int((s.endTarget-startTarget)/serie.Interval + 1)
 		datapoints := pointSlicePool.GetMin(size)
 		for i := 0; i < size; i++ {
 			datapoint := schema.Point{
-				Val: offset + (float64(startTargetAt)+float64(i)*float64(serie.Interval))*factor,
-				Ts:  startTargetAt + uint32(i)*serie.Interval,
+				Val: offset + (float64(startTarget)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  startTarget + uint32(i)*serie.Interval,
 			}
 			datapoints = append(datapoints, datapoint)
 		}
 
 		newSeries := serie.Copy([]schema.Point{})
-		newSeries.Target = fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.parsedStartSourceAt, s.parsedEndSourceAt)
+		newSeries.Target = fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startSource, s.endSource)
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.parsedStartSourceAt, s.parsedEndSourceAt)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startSource, s.endSource) // todo clear tags?
 		newSeries.QueryPatt = newSeries.Target
-		newSeries.QueryFrom = s.startTargetAt
-		newSeries.QueryTo = s.endTargetAt
+		newSeries.QueryFrom = s.startTarget
+		newSeries.QueryTo = s.endTarget
 
 		results = append(results, newSeries)
 	}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -1,18 +1,21 @@
 package expr
 
 import (
-	"time"
+	//"time"
 	"fmt"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
-	"github.com/raintank/dur"
+	//"github.com/raintank/dur"
 )
 
 type FuncLinearRegression struct {
 	in            GraphiteFunc
 	startSourceAt string
 	endSourceAt   string
+
+	start uint32
+	end uint32
 }
 
 func NewLinearRegression() GraphiteFunc {
@@ -41,6 +44,9 @@ func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
 }
 
 func (s *FuncLinearRegression) Context(context Context) Context {
+	s.start = context.from
+	s.end = context.to 
+
 	return context
 }
 
@@ -75,7 +81,7 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 }
 
 func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
-	loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
+	/*loc, err := time.LoadLocation("") // todo, no idea what timezone to use here, utc is a reasonable default
 	if err != nil {
 		return nil, err // todo wrap
 	}
@@ -83,7 +89,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	now := time.Now()
 
 	// todo this should account for empty params assuming thats how unspecified optional string args manifest
-	from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
+	/*from, err := dur.ParseDateTime(s.startSourceAt, loc, now, uint32(now.Add(-24*time.Hour).Unix()))
 	if err != nil {
 		return nil, err // todo wrap
 	}
@@ -91,7 +97,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	to, err := dur.ParseDateTime(s.endSourceAt, loc, now, uint32(now.Unix()))
 	if err != nil {
 		return nil, err // todo wrap
-	}
+	}*/// todo pass these into the linear regression function since that series might have more data than what we want to poll from
 
 	// todo update context.from and .to if needed?
 
@@ -100,8 +106,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		return nil, err
 	}
 
-	var start uint32 = 1200
-	var end uint32 = 1500
+	// these values come from the request context but we don't have access to that context in Exec..
 	results := []models.Series{}
 	for _, serie := range series {
 		factor, offset, forecast := linearRegressionAnalysis(serie)
@@ -110,13 +115,13 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		fmt.Println("size", (end - start) / serie.Interval)
-		datapoints := []schema.Point{}//make([]schema.Point, (end - start) / serie.Interval)
+		fmt.Println("size", (s.end - s.start) / serie.Interval)
+		datapoints := []schema.Point{}//make([]schema.Point, (s.end - s.start) / serie.Interval)
 		var i uint32
-		for i = 0; i <= (end - start) / serie.Interval; i++ {//for i, _ := range serie.Datapoints {
+		for i = 0; i <= (s.end - s.start) / serie.Interval; i++ {//for i, _ := range serie.Datapoints {
 			datapoints = append(datapoints, schema.Point{
-				Val: offset + (float64(start) + float64(i) * float64(serie.Interval)) * factor,
-				Ts: start + i * serie.Interval,
+				Val: offset + (float64(s.start) + float64(i) * float64(serie.Interval)) * factor,
+				Ts: s.start + i * serie.Interval,
 			})
 		}
 
@@ -125,8 +130,8 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			Tags: map[string]string{},
 			Interval: serie.Interval,
 			QueryPatt: "todo",
-			QueryFrom: from,
-			QueryTo: to,
+			QueryFrom: s.start,
+			QueryTo: s.end,
 			QueryCons: serie.QueryCons,
 			Consolidator: serie.Consolidator,
 			QueryMDP: serie.QueryMDP,

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -120,10 +120,12 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
 
-		datapoints := pointSlicePool.GetMin(int((endTargetAt - startTargetAt) / deducedInterval))
-                //for i := 0; i < int((s.endTargetAt - startTargetAt) / deducedInterval); i++ {
-		for i := 0; i < int((endTargetAt - startTargetAt) / deducedInterval); i++ {
-			fmt.Println("startTargetAt:", startTargetAt, "i:", i)
+		size := (endTargetAt - startTargetAt) / deducedInterval
+		if (endTargetAt - startTargetAt) % deducedInterval == 0 {
+			size++
+		}
+		datapoints := pointSlicePool.GetMin(int(size))
+                for i := 0; i < int((endTargetAt - startTargetAt) / deducedInterval); i++ {
 			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,
 				Ts:  startTargetAt + uint32(i)*deducedInterval,

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -109,7 +109,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startSource, s.endSource)
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startSource, s.endSource) // todo clear tags?
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startSource, s.endSource)
 		newSeries.QueryPatt = newSeries.Target
 		newSeries.QueryFrom = s.startTarget
 		newSeries.QueryTo = s.endTarget

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -116,7 +116,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		datapoints := []schema.Point{} //make([]schema.Point, (s.endTargetAt - s.startTargetAt) / serie.Interval)
+		datapoints := []schema.Point{}
 		var i uint32
 		for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {
 			datapoints = append(datapoints, schema.Point{
@@ -126,7 +126,6 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startSourceAt, endSourceAt)
-
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
@@ -134,7 +133,6 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 		newSeries.QueryPatt = name
 		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt
-
 		results = append(results, newSeries)
 	}
 

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
@@ -43,7 +44,6 @@ func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
 }
 
 func (s *FuncLinearRegression) Context(context Context) Context {
-	// im assuming from/to correspond to the python startTime/endTime here
 	s.startTargetAt = context.from
 	s.endTargetAt = context.to
 
@@ -57,30 +57,22 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 	var sumII float64
 	var sumV float64
 	var sumIV float64
-	for _, v := range series.Datapoints {
-		if v.Ts < startSourceAt { // todo can optimize assuming this is sorted
-			continue
-		}
-		if v.Ts > endSourceAt {
-			break
-		}
 
+	for i := sort.Search(len(series.Datapoints), func(i int) bool { return series.Datapoints[i].Ts >= startSourceAt }); i < len(series.Datapoints) && series.Datapoints[i].Ts <= endSourceAt; i++ {
 		// we can't use the index from the datapoints because missing datapoints
 		// do not exist
 		// todo make this sound more better
-		i := (v.Ts - series.QueryFrom) / series.Interval
-		sumI += float64(i)
-		sumII += float64(i) * float64(i)
-		sumV += v.Val
-		sumIV += float64(i) * v.Val
+		index := (series.Datapoints[i].Ts - series.QueryFrom) / series.Interval
+		sumI += float64(index)
+		sumII += float64(index) * float64(index)
+		sumV += series.Datapoints[i].Val
+		sumIV += float64(index) * series.Datapoints[i].Val
 	}
-	fmt.Println("sumI", sumI, "sumII", sumII, "sumV", sumV, "sumIV", sumIV)
 
 	denominator := n*sumII - sumI*sumI
 	if denominator == 0 {
 		return 0, 0, false
 	}
-	fmt.Println("denominator", denominator)
 
 	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)         // todo double check interval is correct to use here
 	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(series.QueryFrom) // todo double check queryfrom is correct to use here
@@ -117,12 +109,10 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	results := []models.Series{}
 	for _, serie := range series {
 		factor, offset, forecast := linearRegressionAnalysis(serie, startSourceAt, endSourceAt)
-		fmt.Println("factor", factor, "offset", offset, "forecast", forecast)
 		if !forecast {
 			continue
 		}
 
-		fmt.Println("size", (s.endTargetAt-s.startTargetAt)/serie.Interval)
 		datapoints := []schema.Point{} //make([]schema.Point, (s.endTargetAt - s.startTargetAt) / serie.Interval)
 		var i uint32
 		for i = 0; i <= (s.endTargetAt-s.startTargetAt)/serie.Interval; i++ {

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -34,13 +34,13 @@ func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
 			ArgString{
 				key:       "startSourceAt",
 				opt:       true,
-				validator: []Validator{IsATTime},
+				validator: []Validator{IsRenderTimeFormat},
 				val:       &s.startSourceAt,
 			},
 			ArgString{
 				key:       "endSourceAt",
 				opt:       true,
-				validator: []Validator{IsATTime},
+				validator: []Validator{IsRenderTimeFormat},
 				val:       &s.endSourceAt,
 			},
 		},

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -54,8 +54,8 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	if err := s.parseSourceAt(); err != nil {
 		fmt.Println("DOM DEBUG PARSE ERR:", err)
 	}// todo handle error
-	context.from = s.parsedStartSourceAt
-	context.to = s.parsedEndSourceAt
+	//context.from = s.parsedStartSourceAt
+	//context.to = s.parsedEndSourceAt
 
 	return context
 }
@@ -105,34 +105,39 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 	results := []models.Series{}
 	for _, serie := range series {
 		fmt.Println("DOM DEBUG series:", serie)
-		factor, offset, isValid := linearRegressionAnalysis(serie, s.parsedStartSourceAt, s.parsedEndSourceAt)
-		if !isValid {
-			continue
-		}
-
 		deducedInterval := deduceInterval(serie)
 		fmt.Println("DOM DEBUG acutal interval:", serie.Interval, "deduced:", deducedInterval)
 		startTargetAt := normalize(s.startTargetAt, deducedInterval)
 		fmt.Println("DOM DEBUG base start target at:", s.startTargetAt, "normalized", startTargetAt)
 
+		factor, offset, isValid := linearRegressionAnalysis(serie, startTargetAt)
+		if !isValid {
+			continue
+		}
+		fmt.Println("DOM DEBUG factor:", factor, "offset:", offset)
+
 		datapoints := pointSlicePool.GetMin(int((s.endTargetAt - startTargetAt) / deducedInterval))
 		for i, _ := range serie.Datapoints {
-			datapoints = append(datapoints, schema.Point{
+			fmt.Println("startTargetAt:", startTargetAt, "i:", i)
+			datapoint := schema.Point{
 				Val: offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor,
 				Ts:  startTargetAt + uint32(i)*deducedInterval,
-			})
+			}
+			fmt.Println("DOM DEBUG:", offset, "+ (", startTargetAt, "+", i, "*", deducedInterval, ") *", factor, "=", offset + (float64(startTargetAt)+float64(i)*float64(deducedInterval))*factor, "=", datapoint.Val, "@", datapoint.Ts)
+			datapoints = append(datapoints, datapoint)
 		}
 
-		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, startTargetAt, s.endTargetAt)
+		name := fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startTargetAt, s.endTargetAt)
 
 		newSeries := serie.Copy([]schema.Point{})
 		newSeries.Target = name
 		newSeries.Datapoints = datapoints
-		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", startTargetAt, s.endTargetAt)
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startTargetAt, s.endTargetAt)
 		newSeries.QueryPatt = name
-		newSeries.QueryFrom = startTargetAt
+		newSeries.QueryFrom = s.startTargetAt
 		newSeries.QueryTo = s.endTargetAt
 
+		fmt.Println("newSeries:", newSeries)
 		results = append(results, newSeries)
 	}
 	return results, nil
@@ -146,13 +151,14 @@ func deduceInterval(series models.Series) uint32 {
 	return series.Datapoints[1].Ts - series.Datapoints[0].Ts
 }
 
-func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSourceAt uint32) (float64, float64, bool) {
+func linearRegressionAnalysis(series models.Series, startSourceAt uint32) (float64, float64, bool) {
 	var n float64
 	var sumI float64
 	var sumII float64
 	var sumV float64
 	var sumIV float64
 
+	fmt.Println("DOM DEBUG series.Interval:", series.Interval, "startSourceAt:", startSourceAt)
 	for i, point := range series.Datapoints {
 		if math.IsNaN(point.Val) {
 			continue
@@ -164,14 +170,15 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 		sumV += point.Val
 		sumIV += float64(i) * point.Val
 	}
+	fmt.Println("DOM DEBUG n:", n, "sumI:", sumI, "sumV:", sumV, "sumII:", sumII, "sumIV:", sumIV)
 
 	denominator := n*sumII - sumI*sumI
+	fmt.Println("DOM DEBUG denominator:", denominator)
 	if denominator == 0 {
 		return 0, 0, false
 	}
 
 	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
 	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSourceAt)
-	fmt.Println("DOM DEBUG sumI:", sumI, "sumII:", sumII, "sumV", sumV, "sumIV", sumIV, "factor:", factor, "offset:", offset)
 	return factor, offset, true
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/schema"
 	"github.com/raintank/dur"
 )
@@ -95,7 +96,7 @@ func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
 			continue
 		}
 
-		normalizedStartTarget := normalize(s.startTarget, serie.Interval)
+		normalizedStartTarget := mdata.AggBoundary(s.startTarget, serie.Interval)
 		size := int((s.endTarget-normalizedStartTarget)/serie.Interval + 1)
 		datapoints := pointSlicePool.GetMin(size)
 		for i := 0; i < size; i++ {
@@ -154,13 +155,4 @@ func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
 	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSource)
 
 	return factor, offset, true
-}
-
-func normalize(timestamp, interval uint32) uint32 {
-	normalized := timestamp / interval * interval
-	if normalized < timestamp {
-		normalized += interval
-	}
-
-	return normalized
 }

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -60,16 +61,15 @@ func linearRegressionAnalysis(series models.Series, startSourceAt uint32, endSou
 	var sumIV float64
 
 	for i := sort.Search(len(series.Datapoints), func(i int) bool { return series.Datapoints[i].Ts >= startSourceAt }); i < len(series.Datapoints) && series.Datapoints[i].Ts <= endSourceAt; i++ {
-		// The index must be rebuilt from the timestamp because
-		// the points of the series do not include "missing" points.
-		index := float64((series.Datapoints[i].Ts - startSourceAt) / series.Interval)
-		value := series.Datapoints[i].Val
+		if math.IsNaN(series.Datapoints[i].Val) {
+			continue
+		}
 
 		n++
-		sumI += index
-		sumII += index * index
-		sumV += value
-		sumIV += index * value
+		sumI += float64(i)
+		sumII += float64(i) * float64(i)
+		sumV += series.Datapoints[i].Val
+		sumIV += float64(i) * series.Datapoints[i].Val
 	}
 
 	denominator := n*sumII - sumI*sumI

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -3,11 +3,13 @@ package expr
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/test"
 )
 
 // todo these tests are black boxd now, unless this is changed to panic
@@ -307,4 +309,65 @@ func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string
 			t.Fatal("Input was modified: ", err)
 		}
 	})
+}
+
+func BenchmarkLinearRegression10k_1NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_10NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_100NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_1000NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewLinearRegression()
+		f.(*FuncLinearRegression).in = NewMock(input)
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
 }

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/metrictank/schema"
 )
 
-func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
+/*func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
 	funcLinearRegression := FuncLinearRegression{
 		startSourceAt: "test",
 	}
@@ -28,7 +28,7 @@ func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
 	if err == nil {
 		t.Fatal("invalid 'endSourceAt' should result in error")
 	}
-}
+}*/
 
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{{
@@ -69,12 +69,12 @@ func TestLinearRegression(t *testing.T) {
 	}}
 
 	expected := []models.Series{{
-		Target: "linearRegression(test.value, 180, 480)",
+		Target: "linearRegression(test.value, 1200, 1500)",
 		Tags: map[string]string{
 			"test":              "value",
-			"linearRegressions": "180, 480",
+			"linearRegressions": "1200, 1500",
 		},
-		QueryPatt: "linearRegression(test.value, 180, 480)",
+		QueryPatt: "linearRegression(test.value, 1200, 1500)",
 		Interval:  60,
 		QueryFrom: 1200,
 		QueryTo:   1500,

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/metrictank/schema"
 )
 
-
 func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
 	funcLinearRegression := FuncLinearRegression{
 		startSourceAt: "test",
@@ -21,7 +20,7 @@ func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
 
 func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
 	funcLinearRegression := FuncLinearRegression{
-		endSourceAt:   "test",
+		endSourceAt: "test",
 	}
 
 	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
@@ -35,40 +34,40 @@ func TestLinearRegressionDefaults(t *testing.T) {
 }
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{{
-			Target: "test.value",
-			Tags: map[string]string{
-				"test": "value",
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: 120,
+		QueryTo:   540,
+		Datapoints: []schema.Point{
+			{
+				Val: -100,
+				Ts:  120,
 			},
-			QueryPatt: "test.value",
-			Interval:  60,
-			QueryFrom: 120,
-			QueryTo:   540,
-			Datapoints: []schema.Point{
-				{
-					Val: -100,
-					Ts:  120,
-				},
-				{
-					Val: 3,
-					Ts:  180,
-				},
-				{
-					Val: 5,
-					Ts:  300,
-				},
-				{
-					Val: 6,
-					Ts:  360,
-				},
-				{
-					Val: 8,
-					Ts:  480,
-				},
-				{
-					Val: 300,
-					Ts:  540,
-				},
+			{
+				Val: 3,
+				Ts:  180,
 			},
+			{
+				Val: 5,
+				Ts:  300,
+			},
+			{
+				Val: 6,
+				Ts:  360,
+			},
+			{
+				Val: 8,
+				Ts:  480,
+			},
+			{
+				Val: 300,
+				Ts:  540,
+			},
+		},
 	}}
 
 	expected := []models.Series{{
@@ -109,21 +108,21 @@ func TestLinearRegression(t *testing.T) {
 		},
 	}}
 
-	context := Context{
-		from: 1200,
-		to:   1500,
-	}
 	funcLinearRegression := FuncLinearRegression{
 		in:            NewMock(in),
 		startSourceAt: "00:03 19700101",
 		endSourceAt:   "00:08 19700101",
 	}
-	funcLinearRegression.Context(context)
-	dataMap := initDataMap(in)
-	actual, err := funcLinearRegression.Exec(dataMap)
+	funcLinearRegression.Context(Context{
+		from: 1200,
+		to:   1500,
+	})
 
+	actual, err := funcLinearRegression.Exec(initDataMap(in))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := equalOutput(expected, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}
-	// todo check tags? its pretty wonky
 }

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -29,9 +29,6 @@ func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
 	}
 }
 
-func TestLinearRegressionDefaults(t *testing.T) {
-	// todo
-}
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{{
 		Target: "test.value",

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,85 +1,85 @@
 package expr
 
 import (
-	"testing"
 	"fmt"
-	
-"github.com/grafana/metrictank/api/models"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
 )
 
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{
 		models.Series{
-		Interval: 60,
-		QueryFrom: 180,
-		QueryTo: 480,
-		Datapoints: []schema.Point{
-			{
-				Val: 3,
-				Ts: 180,
-			},
-			{
-				Val: 5,
-				Ts: 300,
-			},
-			{
-				Val: 6,
-				Ts: 360,
-			},
-			{
-				Val: 8,
-				Ts: 480,
+			Interval:  60,
+			QueryFrom: 180,
+			QueryTo:   480,
+			Datapoints: []schema.Point{
+				{
+					Val: 3,
+					Ts:  180,
+				},
+				{
+					Val: 5,
+					Ts:  300,
+				},
+				{
+					Val: 6,
+					Ts:  360,
+				},
+				{
+					Val: 8,
+					Ts:  480,
+				},
 			},
 		},
-	},
-}
-	
+	}
+
 	expected := models.Series{
-		Target: "todo",
+		Target:    "todo",
 		QueryPatt: "todo",
-		Interval: 60,
+		Interval:  60,
 		QueryFrom: 1200,
-		QueryTo: 1500,
+		QueryTo:   1500,
 		Datapoints: []schema.Point{
 			{
 				Val: 20,
-				Ts: 1200,
+				Ts:  1200,
 			},
 			{
 				Val: 21,
-				Ts: 1260,
+				Ts:  1260,
 			},
 			{
 				Val: 22,
-				Ts: 1320,
+				Ts:  1320,
 			},
 			{
 				Val: 23,
-				Ts: 1380,
+				Ts:  1380,
 			},
 			{
 				Val: 24,
-				Ts: 1440,
+				Ts:  1440,
 			},
 			{
 				Val: 25,
-				Ts: 1500,
+				Ts:  1500,
 			},
 		},
 	}
 
 	context := Context{
 		from: 1200,
-		to: 1500,
+		to:   1500,
 	}
 	funcLinearRegression := FuncLinearRegression{
-		in: NewMock(in),
+		in:            NewMock(in),
 		startSourceAt: "00:03 19700101",
-		endSourceAt: "00:08 19700101",
+		endSourceAt:   "00:08 19700101",
 	}
 	funcLinearRegression.Context(context)
-	dataMap := initDataMap(in) 
+	dataMap := initDataMap(in)
 	actual, err := funcLinearRegression.Exec(dataMap)
 
 	fmt.Println("expected", expected)

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"math"
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
@@ -41,12 +42,12 @@ func TestLinearRegression(t *testing.T) {
 		QueryTo:   540,
 		Datapoints: []schema.Point{
 			{
-				Val: -100,
-				Ts:  120,
-			},
-			{
 				Val: 3,
 				Ts:  180,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  240,
 			},
 			{
 				Val: 5,
@@ -57,12 +58,12 @@ func TestLinearRegression(t *testing.T) {
 				Ts:  360,
 			},
 			{
-				Val: 8,
-				Ts:  480,
+				Val: math.NaN(),
+				Ts:  420,
 			},
 			{
-				Val: 300,
-				Ts:  540,
+				Val: 8,
+				Ts:  480,
 			},
 		},
 	}}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,0 +1,85 @@
+package expr
+
+import (
+	"testing"
+	"fmt"
+	
+"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+)
+
+func TestLinearRegression(t *testing.T) {
+	in := []models.Series{
+		models.Series{
+		Interval: 60,
+		QueryFrom: 180,
+		QueryTo: 480,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts: 180,
+			},
+			{
+				Val: 5,
+				Ts: 300,
+			},
+			{
+				Val: 6,
+				Ts: 360,
+			},
+			{
+				Val: 8,
+				Ts: 480,
+			},
+		},
+	},
+}
+	
+	expected := models.Series{
+		Target: "todo",
+		QueryPatt: "todo",
+		Interval: 60,
+		QueryFrom: 180,//QueryFrom: 1200,
+		QueryTo: 480,//QueryTo: 1500,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts: 1200,
+			},
+			{
+				Val: 21,
+				Ts: 1260,
+			},
+			{
+				Val: 22,
+				Ts: 1320,
+			},
+			{
+				Val: 23,
+				Ts: 1380,
+			},
+			{
+				Val: 24,
+				Ts: 1440,
+			},
+			{
+				Val: 25,
+				Ts: 1500,
+			},
+		},
+	}
+
+	funcLinearRegression := FuncLinearRegression{
+		in: NewMock(in),
+		startSourceAt: "00:03 19700101",
+		endSourceAt: "00:08 19700101",
+	}
+	dataMap := initDataMap(in) 
+	actual, err := funcLinearRegression.Exec(dataMap)
+
+	fmt.Println("expected", expected)
+	fmt.Println("actual", actual)
+	if err := equalOutput([]models.Series{expected}, actual, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/grafana/metrictank/schema"
 )
 
+// todo these tests are black boxd now, unless this is changed to panic
 /*func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
 	funcLinearRegression := FuncLinearRegression{
+		in: NewMock([]models.Series{}),
 		startSourceAt: "test",
 	}
 
@@ -106,21 +108,40 @@ func TestLinearRegression(t *testing.T) {
 		},
 	}}
 
+	testLinearRegression(t, "00:03 19700101", "00:08 19700101", 1200, 1500, in, expected)
+}
+
+func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string, startTargetAt uint32, endTargetAt uint32, input []models.Series, expected []models.Series) {
+	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
+
 	funcLinearRegression := FuncLinearRegression{
-		in:            NewMock(in),
-		startSourceAt: "00:03 19700101",
-		endSourceAt:   "00:08 19700101",
+		in:            NewMock(input),
+		startSourceAt: startSourceAt,
+		endSourceAt:   endSourceAt,
 	}
-	funcLinearRegression.Context(Context{
-		from: 1200,
-		to:   1500,
+
+	context := Context{
+		from: startTargetAt,
+		to:   endTargetAt,
+	}
+	newContext := funcLinearRegression.Context(context)
+	t.Run("ModifiedContext", func(t *testing.T) {
+		if newContext.from == context.from || newContext.to == context.to {
+			t.Fatal("context was not modified by linear regression function")
+		}
 	})
 
-	actual, err := funcLinearRegression.Exec(initDataMap(in))
+	actual, err := funcLinearRegression.Exec(initDataMap(input))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := equalOutput(expected, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}
+
+	t.Run("DidNotModifyInput", func(t *testing.T) {
+		if err := equalOutput(inputCopy, input, nil, nil); err != nil {
+			t.Fatal("Input was modified: ", err)
+		}
+	})
 }

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -290,7 +290,7 @@ func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string
 	newContext := funcLinearRegression.Context(context)
 	t.Run("ModifiedContext", func(t *testing.T) {
 		if newContext.from == context.from || newContext.to == context.to {
-			t.Fatal("context was not modified by linear regression function")
+			t.Fatal("the context is expected to be modified by the linear regression function")
 		}
 	})
 

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -115,7 +115,7 @@ func TestLinearRegression(t *testing.T) {
 
 func TestLinearRegressionRelative(t *testing.T) {
 	now := uint32(time.Now().Unix())
-	now = now / 60 * 60 // normalize as this complicates the test
+	now = now / 60 * 60 // normalize to prevent test fragility
 
 	in := []models.Series{{
 		Target: "test.value",

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -114,7 +115,7 @@ func TestLinearRegression(t *testing.T) {
 
 func TestLinearRegressionRelative(t *testing.T) {
 	now := uint32(time.Now().Unix())
-	now = now / 60 * 60 // normalize to prevent test fragility
+	normalizedNow := now / 60 * 60 // normalize to prevent test fragility
 
 	in := []models.Series{{
 		Target: "test.value",
@@ -123,32 +124,32 @@ func TestLinearRegressionRelative(t *testing.T) {
 		},
 		QueryPatt: "test.value",
 		Interval:  60,
-		QueryFrom: now-1320,
-		QueryTo:   now-1020,
+		QueryFrom: normalizedNow - 1320,
+		QueryTo:   normalizedNow - 1020,
 		Datapoints: []schema.Point{
 			{
 				Val: 3,
-				Ts:  now - 1320,
+				Ts:  normalizedNow - 1320,
 			},
 			{
 				Val: math.NaN(),
-				Ts:  now - 1260,
+				Ts:  normalizedNow - 1260,
 			},
 			{
 				Val: 5,
-				Ts:  now - 1200,
+				Ts:  normalizedNow - 1200,
 			},
 			{
 				Val: 6,
-				Ts:  now - 1140,
+				Ts:  normalizedNow - 1140,
 			},
 			{
 				Val: math.NaN(),
-				Ts:  now - 1080,
+				Ts:  normalizedNow - 1080,
 			},
 			{
 				Val: 8,
-				Ts:  now - 1020,
+				Ts:  normalizedNow - 1020,
 			},
 		},
 	}}
@@ -157,41 +158,41 @@ func TestLinearRegressionRelative(t *testing.T) {
 		Target: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
 		Tags: map[string]string{
 			"test":              "value",
-			"linearRegressions": fmt.Sprintf(%d, %d), now-1320, now-1020),
+			"linearRegressions": fmt.Sprintf("%d, %d", now-1320, now-1020),
 		},
 		QueryPatt: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
 		Interval:  60,
-		QueryFrom: now - 300,
-		QueryTo:   now,
+		QueryFrom: normalizedNow - 300,
+		QueryTo:   normalizedNow,
 		Datapoints: []schema.Point{
 			{
 				Val: 20,
-				Ts:  now - 300,
+				Ts:  normalizedNow - 300,
 			},
 			{
 				Val: 21,
-				Ts:  now - 240,
+				Ts:  normalizedNow - 240,
 			},
 			{
 				Val: 22,
-				Ts:  now - 180,
+				Ts:  normalizedNow - 180,
 			},
 			{
 				Val: 23,
-				Ts:  now - 180,
+				Ts:  normalizedNow - 120,
 			},
 			{
 				Val: 24,
-				Ts:  now - 60,
+				Ts:  normalizedNow - 60,
 			},
 			{
 				Val: 25,
-				Ts:  now,
+				Ts:  normalizedNow,
 			},
 		},
 	}}
 
-	testLinearRegression(t, "now-1320s", "now-1020s", now-300, now, in, expected)
+	testLinearRegression(t, "now-1320s", "now-1020s", normalizedNow-300, normalizedNow, in, expected)
 }
 
 func TestLinearRegressionNormalization(t *testing.T) {

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -129,27 +129,27 @@ func TestLinearRegressionRelative(t *testing.T) {
 		Datapoints: []schema.Point{
 			{
 				Val: 3,
-				Ts:  now-1320,
+				Ts:  now - 1320,
 			},
 			{
 				Val: math.NaN(),
-				Ts:  now-1260,
+				Ts:  now - 1260,
 			},
 			{
 				Val: 5,
-				Ts:  now-1200,
+				Ts:  now - 1200,
 			},
 			{
 				Val: 6,
-				Ts:  now-1140,
+				Ts:  now - 1140,
 			},
 			{
 				Val: math.NaN(),
-				Ts:  now-1080,
+				Ts:  now - 1080,
 			},
 			{
 				Val: 8,
-				Ts:  now-1020,
+				Ts:  now - 1020,
 			},
 		},
 	}}
@@ -162,28 +162,28 @@ func TestLinearRegressionRelative(t *testing.T) {
 		},
 		QueryPatt: "linearRegression(test.value, 180, 480)",
 		Interval:  60,
-		QueryFrom: now-300,
+		QueryFrom: now - 300,
 		QueryTo:   now,
 		Datapoints: []schema.Point{
 			{
 				Val: 20,
-				Ts:  now-300,
+				Ts:  now - 300,
 			},
 			{
 				Val: 21,
-				Ts:  now-240,
+				Ts:  now - 240,
 			},
 			{
 				Val: 22,
-				Ts:  now-180,
+				Ts:  now - 180,
 			},
 			{
 				Val: 23,
-				Ts:  now-120,
+				Ts:  now - 120,
 			},
 			{
 				Val: 24,
-				Ts:  now-60,
+				Ts:  now - 60,
 			},
 			{
 				Val: 25,
@@ -193,6 +193,85 @@ func TestLinearRegressionRelative(t *testing.T) {
 	}}
 
 	testLinearRegression(t, "00:03 19700101", "00:08 19700101", now-300, now, in, expected)
+}
+
+func TestLinearRegressionNormalization(t *testing.T) {
+	in := []models.Series{{
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: 120,
+		QueryTo:   540,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts:  180,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  240,
+			},
+			{
+				Val: 5,
+				Ts:  300,
+			},
+			{
+				Val: 6,
+				Ts:  360,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  420,
+			},
+			{
+				Val: 8,
+				Ts:  480,
+			},
+		},
+	}}
+
+	expected := []models.Series{{
+		Target: "linearRegression(test.value, 180, 480)",
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": "180, 480",
+		},
+		QueryPatt: "linearRegression(test.value, 180, 480)",
+		Interval:  60,
+		QueryFrom: 1199,
+		QueryTo:   1501,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts:  1200,
+			},
+			{
+				Val: 21,
+				Ts:  1260,
+			},
+			{
+				Val: 22,
+				Ts:  1320,
+			},
+			{
+				Val: 23,
+				Ts:  1380,
+			},
+			{
+				Val: 24,
+				Ts:  1440,
+			},
+			{
+				Val: 25,
+				Ts:  1500,
+			},
+		},
+	}}
+
+	testLinearRegression(t, "00:03 19700101", "00:08 19700101", 1199, 1501, in, expected)
 }
 
 func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string, startTargetAt uint32, endTargetAt uint32, input []models.Series, expected []models.Series) {

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -16,9 +16,13 @@ func TestLinearRegression(t *testing.T) {
 			},
 			QueryPatt: "test.value",
 			Interval:  60,
-			QueryFrom: 180,
-			QueryTo:   480,
+			QueryFrom: 120,
+			QueryTo:   540,
 			Datapoints: []schema.Point{
+				{
+					Val: -100,
+					Ts:  120,
+				},
 				{
 					Val: 3,
 					Ts:  180,
@@ -34,6 +38,10 @@ func TestLinearRegression(t *testing.T) {
 				{
 					Val: 8,
 					Ts:  480,
+				},
+				{
+					Val: 300,
+					Ts:  540,
 				},
 			},
 		},

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -42,8 +41,8 @@ func TestLinearRegression(t *testing.T) {
 		},
 		QueryPatt: "test.value",
 		Interval:  60,
-		QueryFrom: 120,
-		QueryTo:   540,
+		QueryFrom: 180,
+		QueryTo:   480,
 		Datapoints: []schema.Point{
 			{
 				Val: 3,
@@ -124,8 +123,8 @@ func TestLinearRegressionRelative(t *testing.T) {
 		},
 		QueryPatt: "test.value",
 		Interval:  60,
-		QueryFrom: 120,
-		QueryTo:   540,
+		QueryFrom: now-1320,
+		QueryTo:   now-1020,
 		Datapoints: []schema.Point{
 			{
 				Val: 3,
@@ -155,12 +154,12 @@ func TestLinearRegressionRelative(t *testing.T) {
 	}}
 
 	expected := []models.Series{{
-		Target: "linearRegression(test.value, 180, 480)",
+		Target: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
 		Tags: map[string]string{
 			"test":              "value",
-			"linearRegressions": "180, 480",
+			"linearRegressions": fmt.Sprintf(%d, %d), now-1320, now-1020),
 		},
-		QueryPatt: "linearRegression(test.value, 180, 480)",
+		QueryPatt: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
 		Interval:  60,
 		QueryFrom: now - 300,
 		QueryTo:   now,
@@ -179,7 +178,7 @@ func TestLinearRegressionRelative(t *testing.T) {
 			},
 			{
 				Val: 23,
-				Ts:  now - 120,
+				Ts:  now - 180,
 			},
 			{
 				Val: 24,
@@ -192,7 +191,7 @@ func TestLinearRegressionRelative(t *testing.T) {
 		},
 	}}
 
-	testLinearRegression(t, "00:03 19700101", "00:08 19700101", now-300, now, in, expected)
+	testLinearRegression(t, "now-1320s", "now-1020s", now-300, now, in, expected)
 }
 
 func TestLinearRegressionNormalization(t *testing.T) {
@@ -203,8 +202,8 @@ func TestLinearRegressionNormalization(t *testing.T) {
 		},
 		QueryPatt: "test.value",
 		Interval:  60,
-		QueryFrom: 120,
-		QueryTo:   540,
+		QueryFrom: 180,
+		QueryTo:   480,
 		Datapoints: []schema.Point{
 			{
 				Val: 3,

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -39,8 +39,8 @@ func TestLinearRegression(t *testing.T) {
 		Target: "todo",
 		QueryPatt: "todo",
 		Interval: 60,
-		QueryFrom: 180,//QueryFrom: 1200,
-		QueryTo: 480,//QueryTo: 1500,
+		QueryFrom: 1200,
+		QueryTo: 1500,
 		Datapoints: []schema.Point{
 			{
 				Val: 20,
@@ -69,11 +69,16 @@ func TestLinearRegression(t *testing.T) {
 		},
 	}
 
+	context := Context{
+		from: 1200,
+		to: 1500,
+	}
 	funcLinearRegression := FuncLinearRegression{
 		in: NewMock(in),
 		startSourceAt: "00:03 19700101",
 		endSourceAt: "00:08 19700101",
 	}
+	funcLinearRegression.Context(context)
 	dataMap := initDataMap(in) 
 	actual, err := funcLinearRegression.Exec(dataMap)
 

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -7,9 +7,34 @@ import (
 	"github.com/grafana/metrictank/schema"
 )
 
+
+func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
+	funcLinearRegression := FuncLinearRegression{
+		startSourceAt: "test",
+	}
+
+	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
+	if err == nil {
+		t.Fatal("invalid 'startSourceAt' should result in error")
+	}
+}
+
+func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
+	funcLinearRegression := FuncLinearRegression{
+		endSourceAt:   "test",
+	}
+
+	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
+	if err == nil {
+		t.Fatal("invalid 'endSourceAt' should result in error")
+	}
+}
+
+func TestLinearRegressionDefaults(t *testing.T) {
+	// todo
+}
 func TestLinearRegression(t *testing.T) {
-	in := []models.Series{
-		models.Series{
+	in := []models.Series{{
 			Target: "test.value",
 			Tags: map[string]string{
 				"test": "value",
@@ -44,10 +69,9 @@ func TestLinearRegression(t *testing.T) {
 					Ts:  540,
 				},
 			},
-		},
-	}
+	}}
 
-	expected := models.Series{
+	expected := []models.Series{{
 		Target: "linearRegression(test.value, 180, 480)",
 		Tags: map[string]string{
 			"test":              "value",
@@ -83,7 +107,7 @@ func TestLinearRegression(t *testing.T) {
 				Ts:  1500,
 			},
 		},
-	}
+	}}
 
 	context := Context{
 		from: 1200,
@@ -98,34 +122,8 @@ func TestLinearRegression(t *testing.T) {
 	dataMap := initDataMap(in)
 	actual, err := funcLinearRegression.Exec(dataMap)
 
-	if err := equalOutput([]models.Series{expected}, actual, nil, err); err != nil {
+	if err := equalOutput(expected, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}
 	// todo check tags? its pretty wonky
-}
-
-func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
-	funcLinearRegression := FuncLinearRegression{
-		startSourceAt: "test",
-	}
-
-	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
-	if err == nil {
-		t.Fatal("invalid 'startSourceAt' should result in error")
-	}
-}
-
-func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
-	funcLinearRegression := FuncLinearRegression{
-		startSourceAt: "test",
-	}
-
-	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
-	if err == nil {
-		t.Fatal("invalid 'endSourceAt' should result in error")
-	}
-}
-
-func TestLinearRegressionDefaults(t *testing.T) {
-	// todo
 }

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -298,7 +298,6 @@ func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println("actual", actual, "expected", expected)
 	if err := equalOutput(expected, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -13,30 +13,6 @@ import (
 	"github.com/grafana/metrictank/test"
 )
 
-// todo these tests are black boxd now, unless this is changed to panic
-/*func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
-	funcLinearRegression := FuncLinearRegression{
-		in: NewMock([]models.Series{}),
-		startSourceAt: "test",
-	}
-
-	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
-	if err == nil {
-		t.Fatal("invalid 'startSourceAt' should result in error")
-	}
-}
-
-func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
-	funcLinearRegression := FuncLinearRegression{
-		endSourceAt: "test",
-	}
-
-	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
-	if err == nil {
-		t.Fatal("invalid 'endSourceAt' should result in error")
-	}
-}*/
-
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{{
 		Target: "test.value",

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -103,3 +103,29 @@ func TestLinearRegression(t *testing.T) {
 	}
 	// todo check tags? its pretty wonky
 }
+
+func TestLinearRegressionInvalidStartSourceAt(t *testing.T) {
+	funcLinearRegression := FuncLinearRegression{
+		startSourceAt: "test",
+	}
+
+	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
+	if err == nil {
+		t.Fatal("invalid 'startSourceAt' should result in error")
+	}
+}
+
+func TestLinearRegressionInvalidEndSourceAt(t *testing.T) {
+	funcLinearRegression := FuncLinearRegression{
+		startSourceAt: "test",
+	}
+
+	_, err := funcLinearRegression.Exec(initDataMap([]models.Series{}))
+	if err == nil {
+		t.Fatal("invalid 'endSourceAt' should result in error")
+	}
+}
+
+func TestLinearRegressionDefaults(t *testing.T) {
+	// todo
+}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -69,12 +69,12 @@ func TestLinearRegression(t *testing.T) {
 	}}
 
 	expected := []models.Series{{
-		Target: "linearRegression(test.value, 1200, 1500)",
+		Target: "linearRegression(test.value, 180, 480)",
 		Tags: map[string]string{
 			"test":              "value",
-			"linearRegressions": "1200, 1500",
+			"linearRegressions": "180, 480",
 		},
-		QueryPatt: "linearRegression(test.value, 1200, 1500)",
+		QueryPatt: "linearRegression(test.value, 180, 480)",
 		Interval:  60,
 		QueryFrom: 1200,
 		QueryTo:   1500,

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,8 +1,10 @@
 package expr
 
 import (
+	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
@@ -111,6 +113,88 @@ func TestLinearRegression(t *testing.T) {
 	testLinearRegression(t, "00:03 19700101", "00:08 19700101", 1200, 1500, in, expected)
 }
 
+func TestLinearRegressionRelative(t *testing.T) {
+	now := uint32(time.Now().Unix())
+	now = now / 60 * 60 // normalize as this complicates the test
+
+	in := []models.Series{{
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: 120,
+		QueryTo:   540,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts:  now-1320,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  now-1260,
+			},
+			{
+				Val: 5,
+				Ts:  now-1200,
+			},
+			{
+				Val: 6,
+				Ts:  now-1140,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  now-1080,
+			},
+			{
+				Val: 8,
+				Ts:  now-1020,
+			},
+		},
+	}}
+
+	expected := []models.Series{{
+		Target: "linearRegression(test.value, 180, 480)",
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": "180, 480",
+		},
+		QueryPatt: "linearRegression(test.value, 180, 480)",
+		Interval:  60,
+		QueryFrom: now-300,
+		QueryTo:   now,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts:  now-300,
+			},
+			{
+				Val: 21,
+				Ts:  now-240,
+			},
+			{
+				Val: 22,
+				Ts:  now-180,
+			},
+			{
+				Val: 23,
+				Ts:  now-120,
+			},
+			{
+				Val: 24,
+				Ts:  now-60,
+			},
+			{
+				Val: 25,
+				Ts:  now,
+			},
+		},
+	}}
+
+	testLinearRegression(t, "00:03 19700101", "00:08 19700101", now-300, now, in, expected)
+}
+
 func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string, startTargetAt uint32, endTargetAt uint32, input []models.Series, expected []models.Series) {
 	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
 
@@ -135,6 +219,7 @@ func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string
 	if err != nil {
 		t.Fatal(err)
 	}
+	fmt.Println("actual", actual, "expected", expected)
 	if err := equalOutput(expected, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -365,6 +365,7 @@ func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []sc
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
+			Interval:  1,
 		}
 		if i%2 == 0 {
 			series.Datapoints = fn0()

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
 	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
@@ -277,6 +278,12 @@ func TestLinearRegressionNormalization(t *testing.T) {
 }
 
 func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string, startTargetAt uint32, endTargetAt uint32, input []models.Series, expected []models.Series) {
+	var err error
+	tz.TimeZone, err = time.LoadLocation("")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
 	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
 
 	funcLinearRegression := FuncLinearRegression{
@@ -348,6 +355,12 @@ func BenchmarkLinearRegression10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkLinearRegression(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var err error
+	tz.TimeZone, err = time.LoadLocation("")
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
@@ -91,9 +90,8 @@ func TestLinearRegression(t *testing.T) {
 	dataMap := initDataMap(in)
 	actual, err := funcLinearRegression.Exec(dataMap)
 
-	fmt.Println("expected", expected)
-	fmt.Println("actual", actual)
 	if err := equalOutput([]models.Series{expected}, actual, nil, err); err != nil {
 		t.Fatal(err)
 	}
+	// todo check tags? its pretty wonky
 }

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -11,6 +11,11 @@ import (
 func TestLinearRegression(t *testing.T) {
 	in := []models.Series{
 		models.Series{
+			Target: "test.value",
+			Tags: map[string]string{
+				"test": "value",
+			},
+			QueryPatt: "test.value",
 			Interval:  60,
 			QueryFrom: 180,
 			QueryTo:   480,
@@ -36,8 +41,12 @@ func TestLinearRegression(t *testing.T) {
 	}
 
 	expected := models.Series{
-		Target:    "todo",
-		QueryPatt: "todo",
+		Target: "linearRegression(test.value, 180, 480)",
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": "180, 480",
+		},
+		QueryPatt: "linearRegression(test.value, 180, 480)",
 		Interval:  60,
 		QueryFrom: 1200,
 		QueryTo:   1500,

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -92,6 +92,7 @@ func init() {
 		"invert":                       {NewInvert, true},
 		"isNonNull":                    {NewIsNonNull, true},
 		"keepLastValue":                {NewKeepLastValue, true},
+		"linearRegression":             {NewLinearRegression, true},
 		"lowest":                       {NewHighestLowestConstructor("", false), true},
 		"lowestAverage":                {NewHighestLowestConstructor("average", false), true},
 		"lowestCurrent":                {NewHighestLowestConstructor("current", false), true},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -92,7 +92,7 @@ func init() {
 		"invert":                       {NewInvert, true},
 		"isNonNull":                    {NewIsNonNull, true},
 		"keepLastValue":                {NewKeepLastValue, true},
-		"linearRegression":             {NewLinearRegression, true},
+		"linearRegression":             {NewLinearRegression, false},
 		"lowest":                       {NewHighestLowestConstructor("", false), true},
 		"lowestAverage":                {NewHighestLowestConstructor("average", false), true},
 		"lowestCurrent":                {NewHighestLowestConstructor("current", false), true},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -92,7 +92,7 @@ func init() {
 		"invert":                       {NewInvert, true},
 		"isNonNull":                    {NewIsNonNull, true},
 		"keepLastValue":                {NewKeepLastValue, true},
-		"linearRegression":             {NewLinearRegression, false},
+		"linearRegression":             {NewLinearRegression, true},
 		"lowest":                       {NewHighestLowestConstructor("", false), true},
 		"lowestAverage":                {NewHighestLowestConstructor("average", false), true},
 		"lowestCurrent":                {NewHighestLowestConstructor("current", false), true},

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/grafana/metrictank/consolidation"
@@ -81,16 +82,18 @@ func WithinZeroOneInclusiveInterval(e *expr) error {
 	return nil
 }
 
-// maybe IsDateTime?
-func IsATTime(e *expr) error {
+// at(1) format
+func IsRenderTimeFormat(e *expr) error {
 	loc, err := time.LoadLocation("")
-	// todo, figure out if there's a point in using a location ehre at all
-	// todo error chekcing
+	if err != nil {
+		return fmt.Errorf("failed to load default timezone location: %w", err)
+	}
 
 	now := time.Now()
 	_, err = dur.ParseDateTime(e.str, loc, now, uint32(now.Unix()))
 	if err != nil {
-		return err // todo probably return something else
+		return fmt.Errorf("failed to parse date time %q: %w", e.str, err)
 	}
+
 	return nil
 }

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -1,6 +1,8 @@
 package expr
 
 import (
+	"time"
+
 	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/errors"
 	"github.com/raintank/dur"
@@ -75,6 +77,20 @@ func NonNegativePercent(e *expr) error {
 func WithinZeroOneInclusiveInterval(e *expr) error {
 	if e.float < 0 || e.float > 1 {
 		return ErrWithinZeroOneInclusiveInterval
+	}
+	return nil
+}
+
+// maybe IsDateTime?
+func IsATTime(e *expr) error {
+	loc, err := time.LoadLocation("")
+	// todo, figure out if there's a point in using a location ehre at all
+	// todo error chekcing
+
+	now := time.Now()
+	_, err = dur.ParseDateTime(e.str, loc, now, uint32(now.Unix()))
+	if err != nil {
+		return err // todo probably return something else
 	}
 	return nil
 }


### PR DESCRIPTION
Last one I swear...

**Describe your changes**
The PR implements the `linearRegression` function natively.

The code follows the [Python implementation](https://github.com/graphite-project/graphite-web/blob/a89711135b0a0a3dfa72310188e2cd33914a6674/webapp/graphite/render/functions.py#L4199-L4260).

**Testing performed**
A basic test case is defined which follows the [Python test](https://github.com/graphite-project/graphite-web/blob/master/webapp/tests/test_functions.py#L4321-L4361). Some additional cases test normalization and relative times.

**Additional context**
Add any other context about your contribution here.
