### PR TITLE
Shutdown server gracefully

### DIFF
--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -532,7 +532,7 @@ func shutdown() {
 	// and so will stop sending us requests.
 	cluster.Stop()
 
-	// stop API
+	// stop API gracefully
 	apiServer.Stop()
 
 	// shutdown our input plugins.  These may take a while as we allow them


### PR DESCRIPTION
Currently the API server shuts down without giving any in-flight requests a chance to finish. This change is to call `Shutdown` on the server and block for a short window to allow these requests to finish successfully. This way, in normal shutdown procedure we should see minimal failures for requests. 

I also think it simplifies the flow, removing a background goroutine/channel