### PR TITLE
Fix PartitionStart in restore command

### DIFF
--- a/cmd/mt-control-server/handlers.go
+++ b/cmd/mt-control-server/handlers.go
@@ -323,7 +323,7 @@ func tagsRestore(ctx *macaron.Context, request controlmodels.IndexRestoreReq) {
 		}
 
 		for p := 0; p < numPartitions; p++ {
-			partitions <- p
+			partitions <- p + request.PartitionStart
 		}
 
 		wg.Wait()


### PR DESCRIPTION
While trying to restore some archived series, it was discovered that we cannot just restore from certain partitions.

**Describe your changes**
Actually use the `PartitionStart` field.

**Testing performed**

**Additional context**
Add any other context about your contribution here.
