### PR TITLE
Support spaces inside aliasSub

### DIFF
--- a/expr/func_aliassub.go
+++ b/expr/func_aliassub.go
@@ -43,7 +43,7 @@ func (s *FuncAliasSub) Exec(dataMap DataMap) ([]models.Series, error) {
 		// TODO - graphite doesn't attempt to extract the
 		// metric/expression from the series. MT probably shouldn't either.
 		// This will almost certainly break some dashboards
-		metric := extractMetric(serie.Target)
+		metric := extractInnerName(serie.Target)
 		if metric == "" {
 			metric = serie.Target
 		}

--- a/expr/func_aliassub_test.go
+++ b/expr/func_aliassub_test.go
@@ -19,6 +19,7 @@ func TestAliasSub(t *testing.T) {
 	testAliasSub(".*\\.([^\\.]+)\\.metrics_received.*", "\\1 in", []string{"metrictank.stats.env.instance.input.pluginname.metrics_received.counter32"}, []string{"pluginname in"}, t)
 	testAliasSub(".*host=([^;]+)(;.*)?", "\\1", []string{"foo.bar.baz;a=b;host=ab1"}, []string{"ab1"}, t)
 	testAliasSub(".*([0-9].+)lue", "\\1", []string{"some.id.of.a.metric.1;my tag=the value"}, []string{"1;my tag=the va"}, t)
+	testAliasSub("(^.*$)", "\\1 A", []string{"str with space"}, []string{"str with space A"}, t)
 }
 
 func testAliasSub(search, replace string, inStr, outStr []string, t *testing.T) {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -556,6 +556,50 @@ func extractMetric(m string) string {
 	return m[start:end]
 }
 
+// extractInnerName is like extractMetric but with a wider character set
+func extractInnerName(m string) string {
+	start := 0
+	end := 0
+	curlyBraces := 0
+	quoteChar := byte(0)
+	allowChars := nameChar + "= " // allow = and space always
+	isAllowedChar := func(r byte) bool {
+		return strings.IndexByte(allowChars, r) >= 0
+	}
+	for end < len(m) {
+		c := m[end]
+		if (c == '\'' || c == '"') && (end == 0 || m[end-1] != '\\') {
+			// Found a non-escaped quote char
+			if quoteChar == 0 {
+				quoteChar = c
+				start = end + 1
+			} else if c == quoteChar {
+				quoteChar = byte(0)
+				start = end + 1
+			}
+		} else if quoteChar == 0 {
+			if c == '{' {
+				curlyBraces++
+			} else if c == '}' {
+				curlyBraces--
+			} else if c == ')' || (c == ',' && curlyBraces == 0) {
+				return m[start:end]
+			} else if !(isAllowedChar(c) || c == ',') {
+				start = end + 1
+			}
+		}
+
+		end++
+	}
+
+	if quoteChar != 0 {
+		log.Warnf("extractInnerName: encountered unterminated string literal in %s", m)
+		return ""
+	}
+
+	return m[start:end]
+}
+
 // aggKey returns a string key by applying the selectors
 // (integers for node positions or strings for tag names) to the given serie
 func aggKey(serie models.Series, nodes []expr) string {

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -1045,3 +1045,73 @@ func TestExtractMetric(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractInnerName(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out string
+	}{
+		{
+			"foo",
+			"foo",
+		},
+		{
+			"perSecond(foo)",
+			"foo",
+		},
+		{
+			"foo.bar",
+			"foo.bar",
+		},
+		{
+			"perSecond(foo.bar",
+			"foo.bar",
+		},
+		{
+			"movingAverage(foo.bar,10)",
+			"foo.bar",
+		},
+		{
+			"scale(scaleToSeconds(nonNegativeDerivative(foo.bar),60),60)",
+			"foo.bar",
+		},
+		{
+			"divideSeries(foo.bar,baz.quux)",
+			"foo.bar",
+		},
+		{
+			"sumSeries(seriesByTag('name=singleQuoted'))",
+			"",
+		},
+		{
+			`sumSeries(seriesByTag("name=doubleQuoted"))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=embeddedQuote"'))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=nonterminatedQuote"))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=\'escapedQuotes\''))`,
+			"",
+		},
+		{
+			"divideSeries(foo.bar;host=1;dc=test,baz.quux;host=1;dc=test)",
+			"foo.bar;host=1;dc=test",
+		},
+		{
+			"func(I have space=inside)",
+			"I have space=inside",
+		},
+	}
+
+	for _, tt := range tests {
+		if m := extractInnerName(tt.in); m != tt.out {
+			t.Errorf("extractInnerName(%q)=%q, want %q", tt.in, m, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
Newer versions of grafana use `aliasSub` around every query. The existing aliasSub behavior will start to cause issues with any queries that have spaces or (e.g. `alias(some description)` ). This is blocking us from upgrading Grafana to the latest versions.

**Describe your changes**

I've duplicated the core `extractMetric` function to create a standalone `extractInnerName` function. This will allow `=` and spaces. I've chosen to duplicate the function to reduce the potential introduction of undesirable behavior for other callers of this function.

**Testing performed**

Added unit tests

**Additional context**
Add any other context about your contribution here.
